### PR TITLE
Refactor GatewayMiddleware Logic

### DIFF
--- a/internal/gateway/middleware/middleware.go
+++ b/internal/gateway/middleware/middleware.go
@@ -23,8 +23,8 @@ import (
 	"github.com/knadh/koanf/v2"
 )
 
-type NewMiddleware func() GatewayMiddleware
 type MiddlewareConfMap map[string]interface{}
+type NewMiddleware func(conf MiddlewareConfMap) (GatewayMiddleware, error)
 
 var BuiltinMiddleware map[string]NewMiddleware = map[string]NewMiddleware{
 	"RegexBasicAuthAllowMiddleware": NewRegexBasicAuthAllowMiddleware,
@@ -39,11 +39,6 @@ type GatewayMiddleware interface {
 
 	// Handler returns the actual Gin HandlerFunc used in the chain
 	Handler(c *gin.Context)
-
-	// Config is used to set the Conf of the Middleware
-	Config(conf MiddlewareConfMap) error
-
-	Name() string
 }
 
 //go:generate moq -out mockmiddlewareconf.go . GatewayMiddlewareConf

--- a/internal/gateway/middleware/mw_header_auth.go
+++ b/internal/gateway/middleware/mw_header_auth.go
@@ -59,7 +59,7 @@ func NewHeaderAuthMiddleware(confMap MiddlewareConfMap) (GatewayMiddleware, erro
 	var mwConf HeaderAuthMiddlewareConf
 
 	if err := LoadMiddlewareConf(&mwConf, confMap); err != nil {
-		return nil, fmt.Errorf("error loading %s config: %w", mwConf.Name(), err)
+		return nil, fmt.Errorf("error creating HeaderAuthMiddleware: %w", err)
 	}
 
 	return &HeaderAuthMiddleware{Headers: mwConf.Headers}, nil

--- a/internal/gateway/middleware/mw_header_auth.go
+++ b/internal/gateway/middleware/mw_header_auth.go
@@ -27,7 +27,7 @@ import (
 // it conforms to requirements set by Spark Gateway admins. The `user` context variable is set to the
 // first header that passes it's configured Validation, if any.
 type HeaderAuthMiddleware struct {
-	Conf HeaderAuthMiddlewareConf
+	Headers []HeaderAuthHeader
 }
 
 type HeaderAuthHeader struct {
@@ -55,29 +55,24 @@ func (h *HeaderAuthMiddlewareConf) Name() string {
 	return "HeaderAuthMiddlewareConf"
 }
 
-func NewHeaderAuthMiddleware() GatewayMiddleware {
-	return &HeaderAuthMiddleware{}
-}
+func NewHeaderAuthMiddleware(confMap MiddlewareConfMap) (GatewayMiddleware, error) {
+	var mwConf HeaderAuthMiddlewareConf
 
-func (h *HeaderAuthMiddleware) Name() string {
-	return "HeaderAuthMiddleware"
+	if err := LoadMiddlewareConf(&mwConf, confMap); err != nil {
+		return nil, fmt.Errorf("error loading %s config: %w", mwConf.Name(), err)
+	}
+
+	return &HeaderAuthMiddleware{Headers: mwConf.Headers}, nil
 }
 
 func (h *HeaderAuthMiddleware) Config(conf MiddlewareConfMap) error {
-	var mwConf HeaderAuthMiddlewareConf
-
-	if err := LoadMiddlewareConf(&mwConf, conf); err != nil {
-		return fmt.Errorf("error loading %s config: %w", mwConf.Name(), err)
-	}
-
-	h.Conf = mwConf
 
 	return nil
 }
 
 func (h *HeaderAuthMiddleware) Handler(c *gin.Context) {
 
-	for _, authHeader := range h.Conf.Headers {
+	for _, authHeader := range h.Headers {
 		if gotHeader := c.GetHeader(authHeader.Key); gotHeader != "" {
 			validateReg := regexp.MustCompile(authHeader.Validation)
 

--- a/internal/gateway/middleware/mw_header_auth_test.go
+++ b/internal/gateway/middleware/mw_header_auth_test.go
@@ -122,10 +122,10 @@ var handlerValidTests = []struct {
 				Validation: ".*",
 			},
 		},
-		reqHeader:   "Header",
-		headerVal:   "headerUser",
+		reqHeader:    "Header",
+		headerVal:    "headerUser",
 		expectedUser: "headerUser",
-		expectedSig: "AB",
+		expectedSig:  "AB",
 	},
 	{
 		test: "No user, invalid header",
@@ -146,9 +146,7 @@ func TestHeaderAuthMiddleware(t *testing.T) {
 	for _, test := range handlerValidTests {
 
 		mw := HeaderAuthMiddleware{
-			Conf: HeaderAuthMiddlewareConf{
-				Headers: test.authHeaders,
-			},
+			Headers: test.authHeaders,
 		}
 
 		t.Run(test.test, func(t *testing.T) {

--- a/internal/gateway/middleware/mw_regex_basic_auth.go
+++ b/internal/gateway/middleware/mw_regex_basic_auth.go
@@ -121,7 +121,11 @@ func (r *RegexBasicAuthAllowMiddleware) Handler(c *gin.Context) {
 func (r *RegexBasicAuthAllowMiddleware) AllowUsername(username string) bool {
 
 	for _, allowRegex := range r.Conf.Allow {
-		allowRe := regexp.MustCompile(allowRegex)
+		allowRe, err := regexp.Compile(allowRegex)
+
+		if err != nil {
+			return false
+		}
 
 		if allowMatch := allowRe.MatchString(username); allowMatch {
 			return true
@@ -202,7 +206,10 @@ func (r *RegexBasicAuthDenyMiddleware) DenyUsername(username string) bool {
 
 	// check deny regexes first
 	for _, denyRegex := range r.Conf.Deny {
-		denyRe := regexp.MustCompile(denyRegex)
+		denyRe, err := regexp.Compile(denyRegex)
+		if err != nil {
+			return false
+		}
 
 		if denyMatch := denyRe.MatchString(username); denyMatch {
 			return true

--- a/internal/gateway/middleware/mw_regex_basic_auth.go
+++ b/internal/gateway/middleware/mw_regex_basic_auth.go
@@ -26,45 +26,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// BaseRegexBasicAuthMiddleware matches the Basic Authorization token against an
-// list of regexes
-type BaseRegexBasicAuthMiddleware struct {
-	Conf BaseRegexBasicAuthMiddlewareConf
-}
-
-type BaseRegexBasicAuthMiddlewareConf struct{}
-
-func (bc *BaseRegexBasicAuthMiddlewareConf) Name() string {
-	return "BaseRegexBasicAuthMiddlewareConf"
-}
-
-func (b *BaseRegexBasicAuthMiddlewareConf) Validate() error {
-	return nil
-}
-
-func NewBaseRegexBasicAuthMiddleware() GatewayMiddleware {
-	return &BaseRegexBasicAuthMiddleware{}
-}
-
-func (b *BaseRegexBasicAuthMiddleware) Config(conf MiddlewareConfMap) error {
-	var mwConf BaseRegexBasicAuthMiddlewareConf
-
-	if err := LoadMiddlewareConf(&mwConf, conf); err != nil {
-		return fmt.Errorf("error loading %s config: %w", mwConf.Name(), err)
-	}
-	b.Conf = mwConf
-
-	return nil
-}
-
-func (b *BaseRegexBasicAuthMiddleware) Handler(c *gin.Context) {}
-
-func (b *BaseRegexBasicAuthMiddleware) Name() string {
-	return "BaseRegexBasicAuthMiddleware"
-}
-
 // GetUserFromAuthHeader ensures a valid Basic authorization header and returns the decoded username.
-func (b *BaseRegexBasicAuthMiddleware) GetUserFromAuthHeader(authHeader string) (string, error) {
+func GetUserFromAuthHeader(authHeader string) (string, error) {
 	authToken := strings.Split(authHeader, "Basic ")
 
 	if len(authToken) != 2 {
@@ -86,18 +49,11 @@ func (b *BaseRegexBasicAuthMiddleware) GetUserFromAuthHeader(authHeader string) 
 	return userPass[0], nil
 }
 
-// Auth will use the regexes defined in BaseRegexBasicAuthMiddlewareConf to determine
-// whether a user is authorized or not.
-func (b *BaseRegexBasicAuthMiddleware) AuthUsername(username string) bool {
-	return false
-}
-
 // RegexBasicAuthAllowMiddleware matches the Basic Authorization token against an
 // allow list of regexes. Will set the context `user` key if the passed
 // basic auth satisfies the allow/deny list criteria. If auth header is missing,
 // the request is denied.
 type RegexBasicAuthAllowMiddleware struct {
-	*BaseRegexBasicAuthMiddleware
 	Conf RegexBasicAuthAllowMiddlewareConf
 }
 
@@ -143,7 +99,7 @@ func (r *RegexBasicAuthAllowMiddleware) Config(conf MiddlewareConfMap) error {
 func (r *RegexBasicAuthAllowMiddleware) Handler(c *gin.Context) {
 
 	if authHeader := c.GetHeader("Authorization"); authHeader != "" {
-		authUser, err := r.GetUserFromAuthHeader(authHeader)
+		authUser, err := GetUserFromAuthHeader(authHeader)
 
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid Authorization header"})
@@ -179,7 +135,6 @@ func (r *RegexBasicAuthAllowMiddleware) AllowUsername(username string) bool {
 // RegexBasicAuthDenyMiddleware matches the Basic Authorization token against an
 // deny list of regexes. If a match is found, the request is denied.
 type RegexBasicAuthDenyMiddleware struct {
-	*BaseRegexBasicAuthMiddleware
 	Conf RegexBasicAuthDenyMiddlewareConf
 }
 
@@ -225,7 +180,7 @@ func (r *RegexBasicAuthDenyMiddleware) Config(conf MiddlewareConfMap) error {
 func (r *RegexBasicAuthDenyMiddleware) Handler(c *gin.Context) {
 
 	if authHeader := c.GetHeader("Authorization"); authHeader != "" {
-		authUser, err := r.GetUserFromAuthHeader(authHeader)
+		authUser, err := GetUserFromAuthHeader(authHeader)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid Authorization header"})
 			return

--- a/internal/gateway/middleware/mw_regex_basic_auth_test.go
+++ b/internal/gateway/middleware/mw_regex_basic_auth_test.go
@@ -54,20 +54,6 @@ var basicAuthGetUserTests = []struct {
 	},
 }
 
-func TestBasicAuthGetUserFromAuthHeader(t *testing.T) {
-	basicAuth := BaseRegexBasicAuthMiddleware{}
-	for _, test := range basicAuthGetUserTests {
-		t.Run(test.test, func(t *testing.T) {
-
-			authToken, err := basicAuth.GetUserFromAuthHeader(test.authHeader)
-			assert.Equal(t, test.expected, authToken, test.test)
-			if err != nil {
-				assert.Contains(t, err.Error(), test.errMsg, "err message matches")
-			}
-		})
-	}
-}
-
 var allowAuthConfValidateTests = []struct {
 	test  string
 	allow []string

--- a/internal/gateway/middleware/mw_regex_basic_auth_test.go
+++ b/internal/gateway/middleware/mw_regex_basic_auth_test.go
@@ -18,6 +18,7 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -27,31 +28,6 @@ import (
 func init() {
 	gin.SetMode(gin.TestMode)
 
-}
-
-var test_str string = "test"
-
-var basicAuthGetUserTests = []struct {
-	test       string
-	authHeader string
-	expected   string
-	errMsg     string
-}{
-	{
-		test:       "auth header missing",
-		authHeader: "",
-		errMsg:     "invalid Authorization format, must be like `Basic <token>`",
-	},
-	{
-		test:       "bad decoding",
-		authHeader: "Authorization Basic decode%%%",
-		errMsg:     "could not decode auth token:",
-	},
-	{
-		test:       "valid auth header",
-		authHeader: "Authorization Basic dGVzdDp0ZXN0",
-		expected:   "test",
-	},
 }
 
 var allowAuthConfValidateTests = []struct {
@@ -97,7 +73,7 @@ func TestAllowRegexBasicAuthConfValidate(t *testing.T) {
 
 var allowAuthHandlerTests = []struct {
 	test           string
-	conf           RegexBasicAuthAllowMiddlewareConf
+	allowRes       []string
 	user           string
 	authHeader     string
 	expectedUser   string
@@ -118,18 +94,27 @@ var allowAuthHandlerTests = []struct {
 		expectedStatus: 403,
 	},
 	{
-		test: "Fail regex",
-		conf: RegexBasicAuthAllowMiddlewareConf{
-			Allow: []string{"valid"},
-		},
+		test:           "Fail regex (deny)",
+		allowRes:       []string{"valid"},
 		authHeader:     "Authorization Basic dGVzdDp0ZXN0",
 		expectedStatus: 403,
 	},
 	{
-		test: "Pass regex",
-		conf: RegexBasicAuthAllowMiddlewareConf{
-			Allow: []string{"test"},
-		},
+		test:           "Pass regex (allow)",
+		allowRes:       []string{"test"},
+		authHeader:     "Authorization Basic dGVzdDp0ZXN0",
+		expectedStatus: 200,
+		expectedUser:   "test",
+	},
+	{
+		test:           "Multiple regex (deny)",
+		allowRes:       []string{"one", "two"},
+		authHeader:     "Authorization Basic dGVzdDp0ZXN0",
+		expectedStatus: 403,
+	},
+	{
+		test:           "Multiple regex (allow)",
+		allowRes:       []string{"one", "test"},
 		authHeader:     "Authorization Basic dGVzdDp0ZXN0",
 		expectedStatus: 200,
 		expectedUser:   "test",
@@ -140,27 +125,29 @@ func TestRegexAllowBasicAuthMiddleware(t *testing.T) {
 
 	for _, test := range allowAuthHandlerTests {
 
+		allowRegexes := []*regexp.Regexp{}
+		for _, allowRe := range test.allowRes {
+			allowRegexes = append(allowRegexes, regexp.MustCompile(allowRe))
+		}
+
 		mw := RegexBasicAuthAllowMiddleware{
-			Conf: test.conf,
+			AllowRegexes: allowRegexes,
 		}
 
 		t.Run(test.test, func(t *testing.T) {
 
 			router := gin.New()
 
-			router.Use(func(c *gin.Context) {
-				c.Set("user", test.user)
-				c.Next()
-			})
-
 			router.Use(mw.Handler)
 
 			// User check
-			router.Use(func(ctx *gin.Context) {
-				userVal, _ := ctx.Get("user")
+			if test.expectedUser != "" {
+				router.Use(func(ctx *gin.Context) {
+					userVal, _ := ctx.Get("user")
 
-				assert.Equal(t, test.expectedUser, userVal, "user value should match")
-			})
+					assert.Equal(t, test.expectedUser, userVal, "user value should match")
+				})
+			}
 
 			router.GET("/")
 
@@ -179,9 +166,8 @@ func TestRegexAllowBasicAuthMiddleware(t *testing.T) {
 
 var denyAuthHandlerTests = []struct {
 	test           string
-	conf           RegexBasicAuthDenyMiddlewareConf
+	denyRes        []string
 	authHeader     string
-	user           string
 	expectedStatus int
 }{
 	{
@@ -199,18 +185,26 @@ var denyAuthHandlerTests = []struct {
 		expectedStatus: 200,
 	},
 	{
-		test: "Fail regex",
-		conf: RegexBasicAuthDenyMiddlewareConf{
-			Deny: []string{"valid"},
-		},
+		test:           "No matches (allow)",
+		denyRes:        []string{"valid"},
 		authHeader:     "Authorization Basic dGVzdDp0ZXN0",
 		expectedStatus: 200,
 	},
 	{
-		test: "Pass regex",
-		conf: RegexBasicAuthDenyMiddlewareConf{
-			Deny: []string{"test"},
-		},
+		test:           "Match regex (deny)",
+		denyRes:        []string{"test"},
+		authHeader:     "Authorization Basic dGVzdDp0ZXN0",
+		expectedStatus: 403,
+	},
+	{
+		test:           "Multiple regex (allow)",
+		denyRes:        []string{"one", "two"},
+		authHeader:     "Authorization Basic dGVzdDp0ZXN0",
+		expectedStatus: 200,
+	},
+	{
+		test:           "Multiple regex (deny)",
+		denyRes:        []string{"one", "test"},
 		authHeader:     "Authorization Basic dGVzdDp0ZXN0",
 		expectedStatus: 403,
 	},
@@ -220,17 +214,17 @@ func TestRegexDenyBasicAuthMiddleware(t *testing.T) {
 
 	for _, test := range denyAuthHandlerTests {
 
+		denyRegexes := []*regexp.Regexp{}
+		for _, denyRe := range test.denyRes {
+			denyRegexes = append(denyRegexes, regexp.MustCompile(denyRe))
+		}
+
 		mw := RegexBasicAuthDenyMiddleware{
-			Conf: test.conf,
+			DenyRegexes: denyRegexes,
 		}
 
 		t.Run(test.test, func(t *testing.T) {
 			router := gin.New()
-
-			router.Use(func(c *gin.Context) {
-				c.Set("user", test.user)
-				c.Next()
-			})
 
 			router.Use(mw.Handler)
 

--- a/internal/gateway/server/server.go
+++ b/internal/gateway/server/server.go
@@ -128,10 +128,7 @@ func NewGateway(ctx context.Context, sgConfig *cfg.SparkGatewayConfig, sparkMana
 		}
 
 		klog.Infof("Initializing middleware [%s]", mwDef.Type)
-		mwImpl := mwNew()
-
-		// Set config
-		err := mwImpl.Config(mwDef.Conf)
+		mwImpl, err := mwNew(mwDef.Conf)
 
 		if err != nil {
 			return nil, fmt.Errorf("error configuring middleware [%s]: %w", mwDef.Type, err)


### PR DESCRIPTION
# Description
* Remove `Name` and `Config` method from GatewayMiddleware interfaces
  * `Name` is unused
  * GatewayMiddleware's are now passed their Koanf confMaps directly to their `New...()` functions, where `MiddlewareConf`s are loaded and validated
  * We now only use `MiddlewareConf`s for Koanf marshaling and validation. Middleware's now contain fields that would be in the Conf for direct access and to reduce complexity
* Remove `BaseRegexBasicAuthMiddleware` as it is unused. This is a relic from prior misunderstanding of golang "inheritance"

# Why
This started as a simple cleanup but realized that a lot of the config logic was quite confusing to parse, especially the ServiceTokenAuthMiddleware and the double loading of it's MiddlewareConf. This reduces a lot of unneeded code and simplifies the creation process of Middlewares in general.