### PR TITLE
Converge onto pointer receivers

### DIFF
--- a/internal/gateway/application/handler/handler.go
+++ b/internal/gateway/application/handler/handler.go
@@ -64,7 +64,7 @@ func NewApplicationHandler(service GatewayApplicationService, defaultLogLines in
 	return &ApplicationHandler{service: service, defaultLogLines: defaultLogLines}
 }
 
-func (h ApplicationHandler) RegisterRoutes(rg *gin.RouterGroup) {
+func (h *ApplicationHandler) RegisterRoutes(rg *gin.RouterGroup) {
 
 	appGroup := rg.Group(fmt.Sprintf("/%s", sparkApplicationPathName))
 	appGroup.Use(pkgHttp.ApplicationErrorHandler)
@@ -93,7 +93,7 @@ func (h ApplicationHandler) RegisterRoutes(rg *gin.RouterGroup) {
 // @Param namespace query string false "Namespace (optional)"
 // @Success 200 {array} metav1.ObjectMeta "List of SparkApplication metadata"
 // @Router / [get]
-func (h ApplicationHandler) List(c *gin.Context) {
+func (h *ApplicationHandler) List(c *gin.Context) {
 
 	cluster := c.Query("cluster")
 	if cluster == "" {
@@ -123,7 +123,7 @@ func (h ApplicationHandler) List(c *gin.Context) {
 // @Param gatewayId path string true "SparkApplication Name"
 // @Success 200 {object} model.GatewayApplication "SparkApplication resource"
 // @Router /{gatewayId} [get]
-func (h ApplicationHandler) Get(c *gin.Context) {
+func (h *ApplicationHandler) Get(c *gin.Context) {
 
 	application, err := h.service.Get(c, c.Param("gatewayId"))
 
@@ -145,7 +145,7 @@ func (h ApplicationHandler) Get(c *gin.Context) {
 // @Param gatewayId path string true "SparkApplication Name"
 // @Success 200 {object} v1beta2.SparkApplicationStatus "SparkApplication status"
 // @Router /{gatewayId}/status [get]
-func (h ApplicationHandler) Status(c *gin.Context) {
+func (h *ApplicationHandler) Status(c *gin.Context) {
 
 	appStatus, err := h.service.Status(c, c.Param("gatewayId"))
 
@@ -168,7 +168,7 @@ func (h ApplicationHandler) Status(c *gin.Context) {
 // @Param lines query int false "Number of log lines to retrieve (default: 100)"
 // @Success 200 {string} string "Driver logs"
 // @Router /{gatewayId}/logs [get]
-func (h ApplicationHandler) Logs(c *gin.Context) {
+func (h *ApplicationHandler) Logs(c *gin.Context) {
 
 	tailLines := h.defaultLogLines
 	var err error
@@ -200,7 +200,7 @@ func (h ApplicationHandler) Logs(c *gin.Context) {
 // @Param SparkApplication body v1beta2.SparkApplication true "v1beta2.SparkApplication resource"
 // @Success 201 {object} model.GatewayApplication "SparkApplication Created"
 // @Router / [post]
-func (h ApplicationHandler) Create(c *gin.Context) {
+func (h *ApplicationHandler) Create(c *gin.Context) {
 
 	var app v1beta2.SparkApplication
 
@@ -237,7 +237,7 @@ func (h ApplicationHandler) Create(c *gin.Context) {
 // @Param gatewayId path string true "SparkApplication Name"
 // @Success 200 {object} map[string]string "Application deleted: {'status': 'success'}"
 // @Router /{gatewayId} [delete]
-func (h ApplicationHandler) Delete(c *gin.Context) {
+func (h *ApplicationHandler) Delete(c *gin.Context) {
 
 	err := h.service.Delete(c, c.Param("gatewayId"))
 

--- a/internal/gateway/application/service/service.go
+++ b/internal/gateway/application/service/service.go
@@ -68,7 +68,7 @@ func NewApplicationService(
 	selectorValue string,
 	gatewayIdGenerator model.GatewayIdGenerator,
 ) handler.GatewayApplicationService {
-	return service{
+	return &service{
 		sparkAppRepo:          sparkAppRepo,
 		clusterRepository:     clusterRepository,
 		clusterRouter:         clusterRouter,
@@ -80,7 +80,7 @@ func NewApplicationService(
 	}
 }
 
-func (s service) GetClusterNamespaceFromGatewayId(gatewayId string) (*model.KubeCluster, string, error) {
+func (s *service) GetClusterNamespaceFromGatewayId(gatewayId string) (*model.KubeCluster, string, error) {
 	clusterId := strings.Split(gatewayId, "-")[0]
 	kubeCluster, err := s.clusterRepository.GetById(clusterId)
 
@@ -97,7 +97,7 @@ func (s service) GetClusterNamespaceFromGatewayId(gatewayId string) (*model.Kube
 	return kubeCluster, namespace.Name, nil
 }
 
-func (s service) Get(ctx context.Context, gatewayId string) (*model.GatewayApplication, error) {
+func (s *service) Get(ctx context.Context, gatewayId string) (*model.GatewayApplication, error) {
 
 	cluster, namespace, err := s.GetClusterNamespaceFromGatewayId(gatewayId)
 	if err != nil {
@@ -127,7 +127,7 @@ func (s service) Get(ctx context.Context, gatewayId string) (*model.GatewayAppli
 }
 
 // List retrieves `num` number of GatewayApplications from specified namespace `namespace` in cluster `cluster`
-func (s service) List(ctx context.Context, cluster string, namespace string) ([]*metav1.ObjectMeta, error) {
+func (s *service) List(ctx context.Context, cluster string, namespace string) ([]*metav1.ObjectMeta, error) {
 
 	kubeCluster, err := s.clusterRepository.GetByName(cluster)
 
@@ -162,7 +162,7 @@ func (s service) List(ctx context.Context, cluster string, namespace string) ([]
 
 }
 
-func (s service) Create(ctx context.Context, application *v1beta2.SparkApplication, user string) (*model.GatewayApplication, error) {
+func (s *service) Create(ctx context.Context, application *v1beta2.SparkApplication, user string) (*model.GatewayApplication, error) {
 
 	errors := s.SparkApplicationValidator(application)
 	if len(errors) > 0 {
@@ -207,7 +207,7 @@ func (s service) Create(ctx context.Context, application *v1beta2.SparkApplicati
 	return gatewayApp, nil
 }
 
-func (s service) Status(ctx context.Context, gatewayId string) (*v1beta2.SparkApplicationStatus, error) {
+func (s *service) Status(ctx context.Context, gatewayId string) (*v1beta2.SparkApplicationStatus, error) {
 	cluster, namespace, err := s.GetClusterNamespaceFromGatewayId(gatewayId)
 	if err != nil {
 		return nil, err
@@ -221,7 +221,7 @@ func (s service) Status(ctx context.Context, gatewayId string) (*v1beta2.SparkAp
 	return &sparkApp.Status, nil
 }
 
-func (s service) Logs(ctx context.Context, gatewayId string, tailLines int) (*string, error) {
+func (s *service) Logs(ctx context.Context, gatewayId string, tailLines int) (*string, error) {
 	cluster, namespace, err := s.GetClusterNamespaceFromGatewayId(gatewayId)
 	if err != nil {
 		return nil, err
@@ -235,7 +235,7 @@ func (s service) Logs(ctx context.Context, gatewayId string, tailLines int) (*st
 	return logString, nil
 }
 
-func (s service) Delete(ctx context.Context, gatewayId string) error {
+func (s *service) Delete(ctx context.Context, gatewayId string) error {
 	cluster, namespace, err := s.GetClusterNamespaceFromGatewayId(gatewayId)
 	if err != nil {
 		return err
@@ -275,7 +275,7 @@ func GetRenderedURLs(templates model.StatusUrlTemplates, sparkApp *v1beta2.Spark
 	}
 }
 
-func (s service) SparkApplicationValidator(application *v1beta2.SparkApplication) []string {
+func (s *service) SparkApplicationValidator(application *v1beta2.SparkApplication) []string {
 	var errors []string
 	if application == nil {
 		errors = append(errors, "application should never be nil")
@@ -304,7 +304,7 @@ func SparkApplicationDefaulter(application *v1beta2.SparkApplication) *v1beta2.S
 	return application
 }
 
-func (s service) SparkApplicationOverrides(application *v1beta2.SparkApplication, user string, appName string) *v1beta2.SparkApplication {
+func (s *service) SparkApplicationOverrides(application *v1beta2.SparkApplication, user string, appName string) *v1beta2.SparkApplication {
 	if application.Name != "" {
 		application.Annotations["applicationName"] = application.Name
 	}

--- a/internal/gateway/cluster/local_repo.go
+++ b/internal/gateway/cluster/local_repo.go
@@ -51,7 +51,7 @@ func NewLocalClusterRepo(clusters []model.KubeCluster) (*LocalClusterRepo, error
 	return &LocalClusterRepo{KubeClusters: clustersById}, nil
 }
 
-func (r LocalClusterRepo) GetByName(cluster string) (*model.KubeCluster, error) {
+func (r *LocalClusterRepo) GetByName(cluster string) (*model.KubeCluster, error) {
 	for _, kubeCluster := range r.KubeClusters {
 		if kubeCluster.Name == cluster {
 			return &kubeCluster, nil
@@ -61,7 +61,7 @@ func (r LocalClusterRepo) GetByName(cluster string) (*model.KubeCluster, error) 
 	return nil, fmt.Errorf("cluster does not exist: %s", cluster)
 }
 
-func (r LocalClusterRepo) GetById(clusterId string) (*model.KubeCluster, error) {
+func (r *LocalClusterRepo) GetById(clusterId string) (*model.KubeCluster, error) {
 
 	cluster, ok := r.KubeClusters[clusterId]
 
@@ -72,7 +72,7 @@ func (r LocalClusterRepo) GetById(clusterId string) (*model.KubeCluster, error) 
 	return &cluster, nil
 }
 
-func (r LocalClusterRepo) GetAll() ([]model.KubeCluster, error) {
+func (r *LocalClusterRepo) GetAll() ([]model.KubeCluster, error) {
 	var clusters []model.KubeCluster
 
 	for _, cluster := range r.KubeClusters {
@@ -86,7 +86,7 @@ func (r LocalClusterRepo) GetAll() ([]model.KubeCluster, error) {
 	return clusters, nil
 }
 
-func (r LocalClusterRepo) GetAllWithNamespace(namespace string) ([]model.KubeCluster, error) {
+func (r *LocalClusterRepo) GetAllWithNamespace(namespace string) ([]model.KubeCluster, error) {
 	var clusters []model.KubeCluster
 
 	allClusters, err := r.GetAll()

--- a/internal/gateway/router/random_router.go
+++ b/internal/gateway/router/random_router.go
@@ -29,11 +29,11 @@ type RandomClusterRouter struct {
 	clusterRepository cluster.ClusterRepository
 }
 
-func NewRandomClusterRouter(repo cluster.ClusterRepository) RandomClusterRouter {
-	return RandomClusterRouter{clusterRepository: repo}
+func NewRandomClusterRouter(repo cluster.ClusterRepository) ClusterRouter {
+	return &RandomClusterRouter{clusterRepository: repo}
 }
 
-func (r RandomClusterRouter) GetCluster(ctx context.Context, namespace string) (*model.KubeCluster, error) {
+func (r *RandomClusterRouter) GetCluster(ctx context.Context, namespace string) (*model.KubeCluster, error) {
 	clusters, err := r.clusterRepository.GetAllWithNamespace(namespace)
 	if err != nil || len(clusters) == 0 {
 		return nil, fmt.Errorf("error listing clusters: %w", err)

--- a/internal/gateway/router/weight_based_random_router.go
+++ b/internal/gateway/router/weight_based_random_router.go
@@ -34,7 +34,7 @@ func NewWeightBasedRandomRouter(
 	clusterRepository cluster.ClusterRepository,
 	clusterRouterConfig cfgPkg.ClusterRouter,
 ) ClusterRouter {
-	return WeightBasedRandomRouter{
+	return &WeightBasedRandomRouter{
 		clusterRepository:   clusterRepository,
 		clusterRouterConfig: clusterRouterConfig,
 	}
@@ -76,7 +76,7 @@ func NewWeightBasedRandomRouter(
 
 	return chosenCluster
 */
-func (r WeightBasedRandomRouter) GetCluster(ctx context.Context, namespace string) (*model.KubeCluster, error) {
+func (r *WeightBasedRandomRouter) GetCluster(ctx context.Context, namespace string) (*model.KubeCluster, error) {
 
 	clustersList, err := r.clusterRepository.GetAllWithNamespace(namespace)
 	if err != nil {

--- a/internal/gateway/router/weight_based_router.go
+++ b/internal/gateway/router/weight_based_router.go
@@ -62,7 +62,7 @@ func NewWeightBasedRouter(
 	metricsServerConfig cfgPkg.MetricsServer,
 	debugPorts map[string]cfgPkg.DebugPort,
 ) ClusterRouter {
-	return WeightBasedRouter{
+	return &WeightBasedRouter{
 		clusterRepository:            clusterRepository,
 		clusterRouterConfig:          clusterRouterConfig,
 		sparkManagerHostnameTemplate: sparkManagerHostnameTemplate,
@@ -107,7 +107,7 @@ func NewWeightBasedRouter(
 	chosen_cluster = max_difference(cluster A difference, cluster C difference) = max(0.04, -0.06) = cluster A
 	return cluster A
 */
-func (r WeightBasedRouter) GetCluster(ctx context.Context, namespace string) (*model.KubeCluster, error) {
+func (r *WeightBasedRouter) GetCluster(ctx context.Context, namespace string) (*model.KubeCluster, error) {
 
 	clustersList, err := r.clusterRepository.GetAllWithNamespace(namespace)
 	if err != nil {

--- a/internal/gateway/server/server.go
+++ b/internal/gateway/server/server.go
@@ -150,7 +150,7 @@ func NewGateway(ctx context.Context, sgConfig *cfg.SparkGatewayConfig, sparkMana
 	}, nil
 }
 
-func (s GatewayServer) Run() {
+func (s *GatewayServer) Run() {
 
 	// Initializing the server in a goroutine so that
 	// it won't block the graceful shutdown handling below

--- a/internal/sparkManager/application/handler/handler.go
+++ b/internal/sparkManager/application/handler/handler.go
@@ -51,7 +51,7 @@ func NewSparkApplicationHandler(sparkApplicationService SparkApplicationService,
 	return &sparkApplicationHandler
 }
 
-func (h SparkApplicationHandler) RegisterRoutes(rg *gin.RouterGroup) {
+func (h *SparkApplicationHandler) RegisterRoutes(rg *gin.RouterGroup) {
 	nsGroup := rg.Group("")
 	nsGroup.Use(pkgHttp.ApplicationErrorHandler)
 	{
@@ -66,7 +66,7 @@ func (h SparkApplicationHandler) RegisterRoutes(rg *gin.RouterGroup) {
 	}
 }
 
-func (h SparkApplicationHandler) Get(c *gin.Context) {
+func (h *SparkApplicationHandler) Get(c *gin.Context) {
 
 	application, err := h.sparkApplicationService.Get(c, c.Param("namespace"), c.Param("name"))
 
@@ -78,7 +78,7 @@ func (h SparkApplicationHandler) Get(c *gin.Context) {
 	c.JSON(http.StatusOK, application)
 }
 
-func (h SparkApplicationHandler) List(c *gin.Context) {
+func (h *SparkApplicationHandler) List(c *gin.Context) {
 	application, err := h.sparkApplicationService.List(c, c.Param("namespace"))
 
 	if err != nil {
@@ -89,7 +89,7 @@ func (h SparkApplicationHandler) List(c *gin.Context) {
 	c.JSON(http.StatusOK, application)
 }
 
-func (h SparkApplicationHandler) Status(c *gin.Context) {
+func (h *SparkApplicationHandler) Status(c *gin.Context) {
 
 	appStatus, err := h.sparkApplicationService.Status(c, c.Param("namespace"), c.Param("name"))
 
@@ -101,7 +101,7 @@ func (h SparkApplicationHandler) Status(c *gin.Context) {
 	c.JSON(http.StatusOK, appStatus)
 }
 
-func (h SparkApplicationHandler) Logs(c *gin.Context) {
+func (h *SparkApplicationHandler) Logs(c *gin.Context) {
 
 	tailLinesStr := c.DefaultQuery("lines", strconv.Itoa(h.defaultLogLines))
 	tailLines, err := strconv.ParseInt(tailLinesStr, 10, 64)
@@ -120,7 +120,7 @@ func (h SparkApplicationHandler) Logs(c *gin.Context) {
 
 }
 
-func (h SparkApplicationHandler) Create(c *gin.Context) {
+func (h *SparkApplicationHandler) Create(c *gin.Context) {
 	var application v1beta2.SparkApplication
 
 	if err := c.ShouldBindJSON(&application); err != nil {
@@ -138,7 +138,7 @@ func (h SparkApplicationHandler) Create(c *gin.Context) {
 	c.JSON(http.StatusCreated, sparkApplication)
 }
 
-func (h SparkApplicationHandler) Delete(c *gin.Context) {
+func (h *SparkApplicationHandler) Delete(c *gin.Context) {
 
 	err := h.sparkApplicationService.Delete(c, c.Param("namespace"), c.Param("name"))
 

--- a/internal/sparkManager/application/repository/repository.go
+++ b/internal/sparkManager/application/repository/repository.go
@@ -46,7 +46,7 @@ func NewSparkApplicationRepository(controller *kube.SparkController, sparkClient
 	}, nil
 }
 
-func (k SparkApplicationRepository) Get(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplication, error) {
+func (k *SparkApplicationRepository) Get(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplication, error) {
 	sparkApp, err := k.controller.SparkLister.SparkApplications(namespace).Get(name)
 
 	if err != nil {
@@ -57,7 +57,7 @@ func (k SparkApplicationRepository) Get(ctx context.Context, namespace string, n
 
 }
 
-func (k SparkApplicationRepository) List(ctx context.Context, namespace string) ([]*v1.ObjectMeta, error) {
+func (k *SparkApplicationRepository) List(ctx context.Context, namespace string) ([]*v1.ObjectMeta, error) {
 	sparkApps, err := k.controller.SparkLister.SparkApplications(namespace).List(labels.Everything())
 
 	if err != nil {
@@ -75,7 +75,7 @@ func (k SparkApplicationRepository) List(ctx context.Context, namespace string) 
 
 }
 
-func (k SparkApplicationRepository) GetLogs(ctx context.Context, namespace string, name string, tailLines int64) (*string, error) {
+func (k *SparkApplicationRepository) GetLogs(ctx context.Context, namespace string, name string, tailLines int64) (*string, error) {
 	sparkApp, err := k.Get(ctx, namespace, name)
 	if err != nil {
 		return nil, gatewayerrors.MapK8sErrorToGatewayError(fmt.Errorf("error getting SparkApplication '%s/%s' to get Spark Driver Pod name for logs: %w", sparkApp.Namespace, sparkApp.Name, err))
@@ -90,7 +90,7 @@ func (k SparkApplicationRepository) GetLogs(ctx context.Context, namespace strin
 	return formattedLogString, nil
 }
 
-func (k SparkApplicationRepository) Create(ctx context.Context, application *v1beta2.SparkApplication) (*v1beta2.SparkApplication, error) {
+func (k *SparkApplicationRepository) Create(ctx context.Context, application *v1beta2.SparkApplication) (*v1beta2.SparkApplication, error) {
 
 	sparkApp, err := k.sparkClient.SparkoperatorV1beta2().SparkApplications(application.Namespace).Create(ctx, application, v1.CreateOptions{})
 	if err != nil {
@@ -124,7 +124,7 @@ func (k SparkApplicationRepository) Create(ctx context.Context, application *v1b
 	return sparkApp, nil
 }
 
-func (k SparkApplicationRepository) Delete(ctx context.Context, namespace string, name string) error {
+func (k *SparkApplicationRepository) Delete(ctx context.Context, namespace string, name string) error {
 	if err := k.sparkClient.SparkoperatorV1beta2().SparkApplications(namespace).Delete(ctx, name, v1.DeleteOptions{}); err != nil {
 		return gatewayerrors.MapK8sErrorToGatewayError(fmt.Errorf("error deleting SparkApplication: %w", err))
 	}

--- a/internal/sparkManager/application/service/service.go
+++ b/internal/sparkManager/application/service/service.go
@@ -46,10 +46,10 @@ type SparkApplicationService struct {
 }
 
 func NewSparkApplicationService(sparkAppRepo SparkApplicationRepository, database repository.DatabaseRepository, cluster model.KubeCluster) handler.SparkApplicationService {
-	return SparkApplicationService{sparkApplicationRepository: sparkAppRepo, database: database, cluster: cluster}
+	return &SparkApplicationService{sparkApplicationRepository: sparkAppRepo, database: database, cluster: cluster}
 }
 
-func (s SparkApplicationService) Get(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplication, error) {
+func (s *SparkApplicationService) Get(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplication, error) {
 
 	sparkApp, err := s.sparkApplicationRepository.Get(ctx, namespace, name)
 
@@ -60,7 +60,7 @@ func (s SparkApplicationService) Get(ctx context.Context, namespace string, name
 	return sparkApp, nil
 }
 
-func (s SparkApplicationService) List(ctx context.Context, namespace string) ([]*metav1.ObjectMeta, error) {
+func (s *SparkApplicationService) List(ctx context.Context, namespace string) ([]*metav1.ObjectMeta, error) {
 
 	sparkApp, err := s.sparkApplicationRepository.List(ctx, namespace)
 
@@ -71,7 +71,7 @@ func (s SparkApplicationService) List(ctx context.Context, namespace string) ([]
 	return sparkApp, nil
 }
 
-func (s SparkApplicationService) Status(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplicationStatus, error) {
+func (s *SparkApplicationService) Status(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplicationStatus, error) {
 	sparkApp, err := s.Get(ctx, namespace, name)
 	if err != nil {
 		return nil, gatewayerrors.NewFrom(err)
@@ -80,11 +80,11 @@ func (s SparkApplicationService) Status(ctx context.Context, namespace string, n
 	return &sparkApp.Status, nil
 }
 
-func (s SparkApplicationService) Logs(ctx context.Context, namespace string, name string, tailLines int64) (*string, error) {
+func (s *SparkApplicationService) Logs(ctx context.Context, namespace string, name string, tailLines int64) (*string, error) {
 	return s.sparkApplicationRepository.GetLogs(ctx, namespace, name, tailLines)
 }
 
-func (s SparkApplicationService) Create(ctx context.Context, application *v1beta2.SparkApplication) (*v1beta2.SparkApplication, error) {
+func (s *SparkApplicationService) Create(ctx context.Context, application *v1beta2.SparkApplication) (*v1beta2.SparkApplication, error) {
 
 	if s.database != nil {
 		uid, err := model.ParseGatewayIdUUID(application.Name)
@@ -107,7 +107,7 @@ func (s SparkApplicationService) Create(ctx context.Context, application *v1beta
 	return sparkApp, nil
 }
 
-func (s SparkApplicationService) Delete(ctx context.Context, namespace string, name string) error {
+func (s *SparkApplicationService) Delete(ctx context.Context, namespace string, name string) error {
 	if err := s.sparkApplicationRepository.Delete(ctx, namespace, name); err != nil {
 		return gatewayerrors.NewFrom(err)
 	}

--- a/pkg/http/health/handler.go
+++ b/pkg/http/health/handler.go
@@ -35,13 +35,13 @@ func NewHealthHandler(service HealthService) *HealthHandler {
 	return &healthHandler
 }
 
-func (h HealthHandler) RegisterRoutes(rg *gin.RouterGroup) {
+func (h *HealthHandler) RegisterRoutes(rg *gin.RouterGroup) {
 	healthGroup := rg.Group("")
 
 	healthGroup.GET("/health", h.Health)
 }
 
-func (h HealthHandler) Health(c *gin.Context) {
+func (h *HealthHandler) Health(c *gin.Context) {
 
 	health := h.service.Health(c)
 

--- a/pkg/http/health/service.go
+++ b/pkg/http/health/service.go
@@ -28,6 +28,6 @@ type HealthResponse struct {
 	Status string `json:"status"`
 }
 
-func (s service) Health(ctx context.Context) HealthResponse {
+func (s *service) Health(ctx context.Context) HealthResponse {
 	return HealthResponse{Status: "OK"}
 }

--- a/pkg/http/health/service.go
+++ b/pkg/http/health/service.go
@@ -20,8 +20,8 @@ import "context"
 type service struct {
 }
 
-func NewHealthService() service {
-	return service{}
+func NewHealthService() *service {
+	return &service{}
 }
 
 type HealthResponse struct {

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -47,7 +47,7 @@ type GatewayIdGenerator struct {
 	UuidGenerator func() (string, error)
 }
 
-func (g GatewayIdGenerator) NewId(cluster KubeCluster, namespace string) (string, error) {
+func (g *GatewayIdGenerator) NewId(cluster KubeCluster, namespace string) (string, error) {
 	// Generate name from clusterId and UUID and set
 	genUUID, err := g.UuidGenerator()
 	if err != nil {

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -35,7 +35,7 @@ type KubeCluster struct {
 	CertificateAuthorityB64File string          `koanf:"certificateAuthorityB64File"`
 }
 
-func (k KubeCluster) GetNamespaceById(namespaceId string) (KubeNamespace, error) {
+func (k *KubeCluster) GetNamespaceById(namespaceId string) (KubeNamespace, error) {
 	for _, kubeNamespace := range k.Namespaces {
 		if kubeNamespace.NamespaceId == namespaceId {
 			return kubeNamespace, nil
@@ -45,7 +45,7 @@ func (k KubeCluster) GetNamespaceById(namespaceId string) (KubeNamespace, error)
 	return KubeNamespace{}, fmt.Errorf("could not find configured namespace with id '%s' in cluster '%s'", namespaceId, k.Name)
 }
 
-func (k KubeCluster) GetNamespaceByName(name string) (*KubeNamespace, error) {
+func (k *KubeCluster) GetNamespaceByName(name string) (*KubeNamespace, error) {
 	for _, kubeNamespace := range k.Namespaces {
 		if kubeNamespace.Name == name {
 			return &kubeNamespace, nil


### PR DESCRIPTION
# Description
Use pointer receivers for all function definitions where possible.

# Why
It's somewhat standard practice at this point to always use receivers. Having a mix can cause confusion and this will improve consistency of our code.