### PR TITLE
Refactor list endpoints to include more metadata

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -58,7 +58,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/v1.ObjectMeta"
+                                "$ref": "#/definitions/model.GatewayApplicationMeta"
                             }
                         }
                     }
@@ -313,6 +313,17 @@ const docTemplate = `{
                 }
             }
         },
+        "model.GatewayApplicationMeta": {
+            "type": "object",
+            "properties": {
+                "cluster": {
+                    "type": "string"
+                },
+                "sparkManagerApplicationMeta": {
+                    "$ref": "#/definitions/model.SparkManagerApplicationMeta"
+                }
+            }
+        },
         "model.SparkLogURLs": {
             "type": "object",
             "properties": {
@@ -323,6 +334,39 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "sparkUI": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.SparkManagerApplicationMeta": {
+            "type": "object",
+            "properties": {
+                "applicationState": {
+                    "$ref": "#/definitions/v1beta2.ApplicationState"
+                },
+                "driverInfo": {
+                    "$ref": "#/definitions/v1beta2.DriverInfo"
+                },
+                "executionAttempts": {
+                    "type": "integer"
+                },
+                "lastSubmissionAttemptTime": {
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/v1.ObjectMeta"
+                },
+                "sparkApplicationId": {
+                    "description": "All fields below come from v1beta2.SparkApplicationStatus\nCurrently it's all fields except for ExecutorState because it can get pretty large",
+                    "type": "string"
+                },
+                "submissionAttempts": {
+                    "type": "integer"
+                },
+                "submissionID": {
+                    "type": "string"
+                },
+                "terminationTime": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -319,7 +319,7 @@ const docTemplate = `{
                 "cluster": {
                     "type": "string"
                 },
-                "sparkManagerApplicationMeta": {
+                "sparkAppMetadata": {
                     "$ref": "#/definitions/model.SparkManagerApplicationMeta"
                 }
             }
@@ -353,7 +353,7 @@ const docTemplate = `{
                 "lastSubmissionAttemptTime": {
                     "type": "string"
                 },
-                "meta": {
+                "metadata": {
                     "$ref": "#/definitions/v1.ObjectMeta"
                 },
                 "sparkApplicationId": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -50,7 +50,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/v1.ObjectMeta"
+                                "$ref": "#/definitions/model.GatewayApplicationMeta"
                             }
                         }
                     }
@@ -305,6 +305,17 @@
                 }
             }
         },
+        "model.GatewayApplicationMeta": {
+            "type": "object",
+            "properties": {
+                "cluster": {
+                    "type": "string"
+                },
+                "sparkManagerApplicationMeta": {
+                    "$ref": "#/definitions/model.SparkManagerApplicationMeta"
+                }
+            }
+        },
         "model.SparkLogURLs": {
             "type": "object",
             "properties": {
@@ -315,6 +326,39 @@
                     "type": "string"
                 },
                 "sparkUI": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.SparkManagerApplicationMeta": {
+            "type": "object",
+            "properties": {
+                "applicationState": {
+                    "$ref": "#/definitions/v1beta2.ApplicationState"
+                },
+                "driverInfo": {
+                    "$ref": "#/definitions/v1beta2.DriverInfo"
+                },
+                "executionAttempts": {
+                    "type": "integer"
+                },
+                "lastSubmissionAttemptTime": {
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/v1.ObjectMeta"
+                },
+                "sparkApplicationId": {
+                    "description": "All fields below come from v1beta2.SparkApplicationStatus\nCurrently it's all fields except for ExecutorState because it can get pretty large",
+                    "type": "string"
+                },
+                "submissionAttempts": {
+                    "type": "integer"
+                },
+                "submissionID": {
+                    "type": "string"
+                },
+                "terminationTime": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -311,7 +311,7 @@
                 "cluster": {
                     "type": "string"
                 },
-                "sparkManagerApplicationMeta": {
+                "sparkAppMetadata": {
                     "$ref": "#/definitions/model.SparkManagerApplicationMeta"
                 }
             }
@@ -345,7 +345,7 @@
                 "lastSubmissionAttemptTime": {
                     "type": "string"
                 },
-                "meta": {
+                "metadata": {
                     "$ref": "#/definitions/v1.ObjectMeta"
                 },
                 "sparkApplicationId": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -36,6 +36,13 @@ definitions:
       user:
         type: string
     type: object
+  model.GatewayApplicationMeta:
+    properties:
+      cluster:
+        type: string
+      sparkManagerApplicationMeta:
+        $ref: '#/definitions/model.SparkManagerApplicationMeta'
+    type: object
   model.SparkLogURLs:
     properties:
       logsUI:
@@ -43,6 +50,30 @@ definitions:
       sparkHistoryUI:
         type: string
       sparkUI:
+        type: string
+    type: object
+  model.SparkManagerApplicationMeta:
+    properties:
+      applicationState:
+        $ref: '#/definitions/v1beta2.ApplicationState'
+      driverInfo:
+        $ref: '#/definitions/v1beta2.DriverInfo'
+      executionAttempts:
+        type: integer
+      lastSubmissionAttemptTime:
+        type: string
+      meta:
+        $ref: '#/definitions/v1.ObjectMeta'
+      sparkApplicationId:
+        description: |-
+          All fields below come from v1beta2.SparkApplicationStatus
+          Currently it's all fields except for ExecutorState because it can get pretty large
+        type: string
+      submissionAttempts:
+        type: integer
+      submissionID:
+        type: string
+      terminationTime:
         type: string
     type: object
   resource.Quantity:
@@ -6353,7 +6384,7 @@ paths:
           description: List of SparkApplication metadata
           schema:
             items:
-              $ref: '#/definitions/v1.ObjectMeta'
+              $ref: '#/definitions/model.GatewayApplicationMeta'
             type: array
       security:
       - BasicAuth: []

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -40,7 +40,7 @@ definitions:
     properties:
       cluster:
         type: string
-      sparkManagerApplicationMeta:
+      sparkAppMetadata:
         $ref: '#/definitions/model.SparkManagerApplicationMeta'
     type: object
   model.SparkLogURLs:
@@ -62,7 +62,7 @@ definitions:
         type: integer
       lastSubmissionAttemptTime:
         type: string
-      meta:
+      metadata:
         $ref: '#/definitions/v1.ObjectMeta'
       sparkApplicationId:
         description: |-

--- a/internal/gateway/application/handler/handler.go
+++ b/internal/gateway/application/handler/handler.go
@@ -30,7 +30,6 @@ import (
 	"github.com/slackhq/spark-gateway/pkg/gatewayerrors"
 	pkgHttp "github.com/slackhq/spark-gateway/pkg/http"
 	"github.com/slackhq/spark-gateway/pkg/model"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 //  Swagger General	API Info
@@ -48,7 +47,7 @@ const sparkApplicationPathName = "applications"
 
 type GatewayApplicationService interface {
 	Get(ctx context.Context, gatewayId string) (*model.GatewayApplication, error)
-	List(ctx context.Context, cluster string, namespace string) ([]*metav1.ObjectMeta, error)
+	List(ctx context.Context, cluster string, namespace string) ([]*model.GatewayApplicationMeta, error)
 	Create(ctx context.Context, application *v1beta2.SparkApplication, user string) (*model.GatewayApplication, error)
 	Status(ctx context.Context, gatewayId string) (*v1beta2.SparkApplicationStatus, error)
 	Logs(ctx context.Context, gatewayId string, tailLines int) (*string, error)
@@ -91,7 +90,7 @@ func (h *ApplicationHandler) RegisterRoutes(rg *gin.RouterGroup) {
 // @Security BasicAuth
 // @Param cluster query string true "Cluster name"
 // @Param namespace query string false "Namespace (optional)"
-// @Success 200 {array} metav1.ObjectMeta "List of SparkApplication metadata"
+// @Success 200 {array} model.GatewayApplicationMeta "List of SparkApplication metadata"
 // @Router / [get]
 func (h *ApplicationHandler) List(c *gin.Context) {
 
@@ -103,14 +102,14 @@ func (h *ApplicationHandler) List(c *gin.Context) {
 
 	namespace := c.Query("namespace")
 
-	applications, err := h.service.List(c, cluster, namespace)
+	appMetaList, err := h.service.List(c, cluster, namespace)
 
 	if err != nil {
 		c.Error(err)
 		return
 	}
 
-	c.JSON(http.StatusOK, applications)
+	c.JSON(http.StatusOK, appMetaList)
 }
 
 // GetSparkApplication godoc

--- a/internal/gateway/application/handler/mockgatewayapplicationservice.go
+++ b/internal/gateway/application/handler/mockgatewayapplicationservice.go
@@ -5,11 +5,9 @@ package handler
 
 import (
 	"context"
-	"sync"
-
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/slackhq/spark-gateway/pkg/model"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sync"
 )
 
 // Ensure, that GatewayApplicationServiceMock does implement GatewayApplicationService.
@@ -31,7 +29,7 @@ var _ GatewayApplicationService = &GatewayApplicationServiceMock{}
 //			GetFunc: func(ctx context.Context, gatewayId string) (*model.GatewayApplication, error) {
 //				panic("mock out the Get method")
 //			},
-//			ListFunc: func(ctx context.Context, cluster string, namespace string) ([]*metav1.ObjectMeta, error) {
+//			ListFunc: func(ctx context.Context, cluster string, namespace string) ([]*model.GatewayApplicationMeta, error) {
 //				panic("mock out the List method")
 //			},
 //			LogsFunc: func(ctx context.Context, gatewayId string, tailLines int) (*string, error) {
@@ -57,7 +55,7 @@ type GatewayApplicationServiceMock struct {
 	GetFunc func(ctx context.Context, gatewayId string) (*model.GatewayApplication, error)
 
 	// ListFunc mocks the List method.
-	ListFunc func(ctx context.Context, cluster string, namespace string) ([]*metav1.ObjectMeta, error)
+	ListFunc func(ctx context.Context, cluster string, namespace string) ([]*model.GatewayApplicationMeta, error)
 
 	// LogsFunc mocks the Logs method.
 	LogsFunc func(ctx context.Context, gatewayId string, tailLines int) (*string, error)
@@ -237,7 +235,7 @@ func (mock *GatewayApplicationServiceMock) GetCalls() []struct {
 }
 
 // List calls ListFunc.
-func (mock *GatewayApplicationServiceMock) List(ctx context.Context, cluster string, namespace string) ([]*metav1.ObjectMeta, error) {
+func (mock *GatewayApplicationServiceMock) List(ctx context.Context, cluster string, namespace string) ([]*model.GatewayApplicationMeta, error) {
 	if mock.ListFunc == nil {
 		panic("GatewayApplicationServiceMock.ListFunc: method is nil but GatewayApplicationService.List was just called")
 	}

--- a/internal/gateway/application/repository/repository.go
+++ b/internal/gateway/application/repository/repository.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/klog/v2"
 
@@ -88,7 +87,7 @@ func (r *SparkManagerRepository) Get(ctx context.Context, cluster model.KubeClus
 	return kube.Sanitize(&app), nil
 }
 
-func (r *SparkManagerRepository) List(ctx context.Context, cluster model.KubeCluster, namespace string) ([]*metav1.ObjectMeta, error) {
+func (r *SparkManagerRepository) List(ctx context.Context, cluster model.KubeCluster, namespace string) ([]*model.SparkManagerApplicationMeta, error) {
 
 	hostname, err := util.RenderTemplate(r.sparkManagerHostnameTemplate, map[string]string{"clusterName": cluster.Name})
 	if err != nil {
@@ -119,12 +118,12 @@ func (r *SparkManagerRepository) List(ctx context.Context, cluster model.KubeClu
 		return nil, gatewayerrors.NewFrom(err)
 	}
 
-	var appMetas []*metav1.ObjectMeta
-	if err := json.Unmarshal(*respBody, &appMetas); err != nil {
+	var appMetaList []*model.SparkManagerApplicationMeta
+	if err := json.Unmarshal(*respBody, &appMetaList); err != nil {
 		return nil, fmt.Errorf("failed to Unmarshal JSON response: %w", err)
 	}
 
-	return appMetas, nil
+	return appMetaList, nil
 }
 
 func (r *SparkManagerRepository) Status(ctx context.Context, cluster model.KubeCluster, namespace string, name string) (*v1beta2.SparkApplicationStatus, error) {

--- a/internal/gateway/application/service/mocksparkapplicationrepository.go
+++ b/internal/gateway/application/service/mocksparkapplicationrepository.go
@@ -5,11 +5,9 @@ package service
 
 import (
 	"context"
-	"sync"
-
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	"github.com/slackhq/spark-gateway/pkg/model"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sync"
 )
 
 // Ensure, that SparkApplicationRepositoryMock does implement SparkApplicationRepository.
@@ -31,7 +29,7 @@ var _ SparkApplicationRepository = &SparkApplicationRepositoryMock{}
 //			GetFunc: func(ctx context.Context, cluster model.KubeCluster, namespace string, name string) (*v1beta2.SparkApplication, error) {
 //				panic("mock out the Get method")
 //			},
-//			ListFunc: func(ctx context.Context, cluster model.KubeCluster, namespace string) ([]*metav1.ObjectMeta, error) {
+//			ListFunc: func(ctx context.Context, cluster model.KubeCluster, namespace string) ([]*model.SparkManagerApplicationMeta, error) {
 //				panic("mock out the List method")
 //			},
 //			LogsFunc: func(ctx context.Context, cluster model.KubeCluster, namespace string, name string, tailLines int) (*string, error) {
@@ -57,7 +55,7 @@ type SparkApplicationRepositoryMock struct {
 	GetFunc func(ctx context.Context, cluster model.KubeCluster, namespace string, name string) (*v1beta2.SparkApplication, error)
 
 	// ListFunc mocks the List method.
-	ListFunc func(ctx context.Context, cluster model.KubeCluster, namespace string) ([]*metav1.ObjectMeta, error)
+	ListFunc func(ctx context.Context, cluster model.KubeCluster, namespace string) ([]*model.SparkManagerApplicationMeta, error)
 
 	// LogsFunc mocks the Logs method.
 	LogsFunc func(ctx context.Context, cluster model.KubeCluster, namespace string, name string, tailLines int) (*string, error)
@@ -269,7 +267,7 @@ func (mock *SparkApplicationRepositoryMock) GetCalls() []struct {
 }
 
 // List calls ListFunc.
-func (mock *SparkApplicationRepositoryMock) List(ctx context.Context, cluster model.KubeCluster, namespace string) ([]*metav1.ObjectMeta, error) {
+func (mock *SparkApplicationRepositoryMock) List(ctx context.Context, cluster model.KubeCluster, namespace string) ([]*model.SparkManagerApplicationMeta, error) {
 	if mock.ListFunc == nil {
 		panic("SparkApplicationRepositoryMock.ListFunc: method is nil but SparkApplicationRepository.List was just called")
 	}

--- a/internal/sparkManager/application/handler/handler_test.go
+++ b/internal/sparkManager/application/handler/handler_test.go
@@ -46,13 +46,13 @@ var expectedSparkApplication v1beta2.SparkApplication = v1beta2.SparkApplication
 var logString string = "testlogstring"
 
 var mockSparkAppService_SuccessTests SparkApplicationServiceMock = SparkApplicationServiceMock{
-	GetFunc: func(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplication, error) {
+	GetFunc: func(namespace string, name string) (*v1beta2.SparkApplication, error) {
 		return &expectedSparkApplication, nil
 	},
-	StatusFunc: func(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplicationStatus, error) {
+	StatusFunc: func(namespace string, name string) (*v1beta2.SparkApplicationStatus, error) {
 		return &expectedSparkApplication.Status, nil
 	},
-	LogsFunc: func(ctx context.Context, namespace string, name string, tailLines int64) (*string, error) {
+	LogsFunc: func(namespace string, name string, tailLines int64) (*string, error) {
 		return &logString, nil
 	},
 	CreateFunc: func(ctx context.Context, application *v1beta2.SparkApplication) (*v1beta2.SparkApplication, error) {
@@ -64,13 +64,13 @@ var mockSparkAppService_SuccessTests SparkApplicationServiceMock = SparkApplicat
 }
 
 var mockSparkAppService_FailureTests SparkApplicationServiceMock = SparkApplicationServiceMock{
-	GetFunc: func(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplication, error) {
+	GetFunc: func(namespace string, name string) (*v1beta2.SparkApplication, error) {
 		return nil, gatewayerrors.NewNotFound(errors.New(fmt.Sprintf("error getting SparkApplication '%s'", expectedSparkApplication.Name)))
 	},
-	StatusFunc: func(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplicationStatus, error) {
+	StatusFunc: func(namespace string, name string) (*v1beta2.SparkApplicationStatus, error) {
 		return nil, gatewayerrors.NewNotFound(errors.New(fmt.Sprintf("error getting SparkApplication '%s'", expectedSparkApplication.Name)))
 	},
-	LogsFunc: func(ctx context.Context, namespace string, name string, tailLines int64) (*string, error) {
+	LogsFunc: func(namespace string, name string, tailLines int64) (*string, error) {
 		return nil, gatewayerrors.NewNotFound(errors.New(fmt.Sprintf("error getting SparkApplication '%s' to get Spark Driver Pod name for logs", expectedSparkApplication.Name)))
 	},
 	CreateFunc: func(ctx context.Context, application *v1beta2.SparkApplication) (*v1beta2.SparkApplication, error) {

--- a/internal/sparkManager/application/handler/mocksparkapplicationservice.go
+++ b/internal/sparkManager/application/handler/mocksparkapplicationservice.go
@@ -6,7 +6,7 @@ package handler
 import (
 	"context"
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/slackhq/spark-gateway/pkg/model"
 	"sync"
 )
 
@@ -26,16 +26,16 @@ var _ SparkApplicationService = &SparkApplicationServiceMock{}
 //			DeleteFunc: func(ctx context.Context, namespace string, name string) error {
 //				panic("mock out the Delete method")
 //			},
-//			GetFunc: func(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplication, error) {
+//			GetFunc: func(namespace string, name string) (*v1beta2.SparkApplication, error) {
 //				panic("mock out the Get method")
 //			},
-//			ListFunc: func(ctx context.Context, namespace string) ([]*metav1.ObjectMeta, error) {
+//			ListFunc: func(namespace string) ([]*model.SparkManagerApplicationMeta, error) {
 //				panic("mock out the List method")
 //			},
-//			LogsFunc: func(ctx context.Context, namespace string, name string, tailLines int64) (*string, error) {
+//			LogsFunc: func(namespace string, name string, tailLines int64) (*string, error) {
 //				panic("mock out the Logs method")
 //			},
-//			StatusFunc: func(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplicationStatus, error) {
+//			StatusFunc: func(namespace string, name string) (*v1beta2.SparkApplicationStatus, error) {
 //				panic("mock out the Status method")
 //			},
 //		}
@@ -52,16 +52,16 @@ type SparkApplicationServiceMock struct {
 	DeleteFunc func(ctx context.Context, namespace string, name string) error
 
 	// GetFunc mocks the Get method.
-	GetFunc func(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplication, error)
+	GetFunc func(namespace string, name string) (*v1beta2.SparkApplication, error)
 
 	// ListFunc mocks the List method.
-	ListFunc func(ctx context.Context, namespace string) ([]*metav1.ObjectMeta, error)
+	ListFunc func(namespace string) ([]*model.SparkManagerApplicationMeta, error)
 
 	// LogsFunc mocks the Logs method.
-	LogsFunc func(ctx context.Context, namespace string, name string, tailLines int64) (*string, error)
+	LogsFunc func(namespace string, name string, tailLines int64) (*string, error)
 
 	// StatusFunc mocks the Status method.
-	StatusFunc func(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplicationStatus, error)
+	StatusFunc func(namespace string, name string) (*v1beta2.SparkApplicationStatus, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -83,8 +83,6 @@ type SparkApplicationServiceMock struct {
 		}
 		// Get holds details about calls to the Get method.
 		Get []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
 			// Namespace is the namespace argument value.
 			Namespace string
 			// Name is the name argument value.
@@ -92,15 +90,11 @@ type SparkApplicationServiceMock struct {
 		}
 		// List holds details about calls to the List method.
 		List []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
 			// Namespace is the namespace argument value.
 			Namespace string
 		}
 		// Logs holds details about calls to the Logs method.
 		Logs []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
 			// Namespace is the namespace argument value.
 			Namespace string
 			// Name is the name argument value.
@@ -110,8 +104,6 @@ type SparkApplicationServiceMock struct {
 		}
 		// Status holds details about calls to the Status method.
 		Status []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
 			// Namespace is the namespace argument value.
 			Namespace string
 			// Name is the name argument value.
@@ -203,23 +195,21 @@ func (mock *SparkApplicationServiceMock) DeleteCalls() []struct {
 }
 
 // Get calls GetFunc.
-func (mock *SparkApplicationServiceMock) Get(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplication, error) {
+func (mock *SparkApplicationServiceMock) Get(namespace string, name string) (*v1beta2.SparkApplication, error) {
 	if mock.GetFunc == nil {
 		panic("SparkApplicationServiceMock.GetFunc: method is nil but SparkApplicationService.Get was just called")
 	}
 	callInfo := struct {
-		Ctx       context.Context
 		Namespace string
 		Name      string
 	}{
-		Ctx:       ctx,
 		Namespace: namespace,
 		Name:      name,
 	}
 	mock.lockGet.Lock()
 	mock.calls.Get = append(mock.calls.Get, callInfo)
 	mock.lockGet.Unlock()
-	return mock.GetFunc(ctx, namespace, name)
+	return mock.GetFunc(namespace, name)
 }
 
 // GetCalls gets all the calls that were made to Get.
@@ -227,12 +217,10 @@ func (mock *SparkApplicationServiceMock) Get(ctx context.Context, namespace stri
 //
 //	len(mockedSparkApplicationService.GetCalls())
 func (mock *SparkApplicationServiceMock) GetCalls() []struct {
-	Ctx       context.Context
 	Namespace string
 	Name      string
 } {
 	var calls []struct {
-		Ctx       context.Context
 		Namespace string
 		Name      string
 	}
@@ -243,21 +231,19 @@ func (mock *SparkApplicationServiceMock) GetCalls() []struct {
 }
 
 // List calls ListFunc.
-func (mock *SparkApplicationServiceMock) List(ctx context.Context, namespace string) ([]*metav1.ObjectMeta, error) {
+func (mock *SparkApplicationServiceMock) List(namespace string) ([]*model.SparkManagerApplicationMeta, error) {
 	if mock.ListFunc == nil {
 		panic("SparkApplicationServiceMock.ListFunc: method is nil but SparkApplicationService.List was just called")
 	}
 	callInfo := struct {
-		Ctx       context.Context
 		Namespace string
 	}{
-		Ctx:       ctx,
 		Namespace: namespace,
 	}
 	mock.lockList.Lock()
 	mock.calls.List = append(mock.calls.List, callInfo)
 	mock.lockList.Unlock()
-	return mock.ListFunc(ctx, namespace)
+	return mock.ListFunc(namespace)
 }
 
 // ListCalls gets all the calls that were made to List.
@@ -265,11 +251,9 @@ func (mock *SparkApplicationServiceMock) List(ctx context.Context, namespace str
 //
 //	len(mockedSparkApplicationService.ListCalls())
 func (mock *SparkApplicationServiceMock) ListCalls() []struct {
-	Ctx       context.Context
 	Namespace string
 } {
 	var calls []struct {
-		Ctx       context.Context
 		Namespace string
 	}
 	mock.lockList.RLock()
@@ -279,17 +263,15 @@ func (mock *SparkApplicationServiceMock) ListCalls() []struct {
 }
 
 // Logs calls LogsFunc.
-func (mock *SparkApplicationServiceMock) Logs(ctx context.Context, namespace string, name string, tailLines int64) (*string, error) {
+func (mock *SparkApplicationServiceMock) Logs(namespace string, name string, tailLines int64) (*string, error) {
 	if mock.LogsFunc == nil {
 		panic("SparkApplicationServiceMock.LogsFunc: method is nil but SparkApplicationService.Logs was just called")
 	}
 	callInfo := struct {
-		Ctx       context.Context
 		Namespace string
 		Name      string
 		TailLines int64
 	}{
-		Ctx:       ctx,
 		Namespace: namespace,
 		Name:      name,
 		TailLines: tailLines,
@@ -297,7 +279,7 @@ func (mock *SparkApplicationServiceMock) Logs(ctx context.Context, namespace str
 	mock.lockLogs.Lock()
 	mock.calls.Logs = append(mock.calls.Logs, callInfo)
 	mock.lockLogs.Unlock()
-	return mock.LogsFunc(ctx, namespace, name, tailLines)
+	return mock.LogsFunc(namespace, name, tailLines)
 }
 
 // LogsCalls gets all the calls that were made to Logs.
@@ -305,13 +287,11 @@ func (mock *SparkApplicationServiceMock) Logs(ctx context.Context, namespace str
 //
 //	len(mockedSparkApplicationService.LogsCalls())
 func (mock *SparkApplicationServiceMock) LogsCalls() []struct {
-	Ctx       context.Context
 	Namespace string
 	Name      string
 	TailLines int64
 } {
 	var calls []struct {
-		Ctx       context.Context
 		Namespace string
 		Name      string
 		TailLines int64
@@ -323,23 +303,21 @@ func (mock *SparkApplicationServiceMock) LogsCalls() []struct {
 }
 
 // Status calls StatusFunc.
-func (mock *SparkApplicationServiceMock) Status(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplicationStatus, error) {
+func (mock *SparkApplicationServiceMock) Status(namespace string, name string) (*v1beta2.SparkApplicationStatus, error) {
 	if mock.StatusFunc == nil {
 		panic("SparkApplicationServiceMock.StatusFunc: method is nil but SparkApplicationService.Status was just called")
 	}
 	callInfo := struct {
-		Ctx       context.Context
 		Namespace string
 		Name      string
 	}{
-		Ctx:       ctx,
 		Namespace: namespace,
 		Name:      name,
 	}
 	mock.lockStatus.Lock()
 	mock.calls.Status = append(mock.calls.Status, callInfo)
 	mock.lockStatus.Unlock()
-	return mock.StatusFunc(ctx, namespace, name)
+	return mock.StatusFunc(namespace, name)
 }
 
 // StatusCalls gets all the calls that were made to Status.
@@ -347,12 +325,10 @@ func (mock *SparkApplicationServiceMock) Status(ctx context.Context, namespace s
 //
 //	len(mockedSparkApplicationService.StatusCalls())
 func (mock *SparkApplicationServiceMock) StatusCalls() []struct {
-	Ctx       context.Context
 	Namespace string
 	Name      string
 } {
 	var calls []struct {
-		Ctx       context.Context
 		Namespace string
 		Name      string
 	}

--- a/internal/sparkManager/application/service/mocksparkapplicationrepository.go
+++ b/internal/sparkManager/application/service/mocksparkapplicationrepository.go
@@ -6,7 +6,7 @@ package service
 import (
 	"context"
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/slackhq/spark-gateway/pkg/model"
 	"sync"
 )
 
@@ -26,13 +26,13 @@ var _ SparkApplicationRepository = &SparkApplicationRepositoryMock{}
 //			DeleteFunc: func(ctx context.Context, namespace string, name string) error {
 //				panic("mock out the Delete method")
 //			},
-//			GetFunc: func(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplication, error) {
+//			GetFunc: func(namespace string, name string) (*v1beta2.SparkApplication, error) {
 //				panic("mock out the Get method")
 //			},
-//			GetLogsFunc: func(ctx context.Context, namespace string, name string, tailLines int64) (*string, error) {
+//			GetLogsFunc: func(namespace string, name string, tailLines int64) (*string, error) {
 //				panic("mock out the GetLogs method")
 //			},
-//			ListFunc: func(ctx context.Context, namespace string) ([]*metav1.ObjectMeta, error) {
+//			ListFunc: func(namespace string) ([]*model.SparkManagerApplicationMeta, error) {
 //				panic("mock out the List method")
 //			},
 //		}
@@ -49,13 +49,13 @@ type SparkApplicationRepositoryMock struct {
 	DeleteFunc func(ctx context.Context, namespace string, name string) error
 
 	// GetFunc mocks the Get method.
-	GetFunc func(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplication, error)
+	GetFunc func(namespace string, name string) (*v1beta2.SparkApplication, error)
 
 	// GetLogsFunc mocks the GetLogs method.
-	GetLogsFunc func(ctx context.Context, namespace string, name string, tailLines int64) (*string, error)
+	GetLogsFunc func(namespace string, name string, tailLines int64) (*string, error)
 
 	// ListFunc mocks the List method.
-	ListFunc func(ctx context.Context, namespace string) ([]*metav1.ObjectMeta, error)
+	ListFunc func(namespace string) ([]*model.SparkManagerApplicationMeta, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -77,8 +77,6 @@ type SparkApplicationRepositoryMock struct {
 		}
 		// Get holds details about calls to the Get method.
 		Get []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
 			// Namespace is the namespace argument value.
 			Namespace string
 			// Name is the name argument value.
@@ -86,8 +84,6 @@ type SparkApplicationRepositoryMock struct {
 		}
 		// GetLogs holds details about calls to the GetLogs method.
 		GetLogs []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
 			// Namespace is the namespace argument value.
 			Namespace string
 			// Name is the name argument value.
@@ -97,8 +93,6 @@ type SparkApplicationRepositoryMock struct {
 		}
 		// List holds details about calls to the List method.
 		List []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
 			// Namespace is the namespace argument value.
 			Namespace string
 		}
@@ -187,23 +181,21 @@ func (mock *SparkApplicationRepositoryMock) DeleteCalls() []struct {
 }
 
 // Get calls GetFunc.
-func (mock *SparkApplicationRepositoryMock) Get(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplication, error) {
+func (mock *SparkApplicationRepositoryMock) Get(namespace string, name string) (*v1beta2.SparkApplication, error) {
 	if mock.GetFunc == nil {
 		panic("SparkApplicationRepositoryMock.GetFunc: method is nil but SparkApplicationRepository.Get was just called")
 	}
 	callInfo := struct {
-		Ctx       context.Context
 		Namespace string
 		Name      string
 	}{
-		Ctx:       ctx,
 		Namespace: namespace,
 		Name:      name,
 	}
 	mock.lockGet.Lock()
 	mock.calls.Get = append(mock.calls.Get, callInfo)
 	mock.lockGet.Unlock()
-	return mock.GetFunc(ctx, namespace, name)
+	return mock.GetFunc(namespace, name)
 }
 
 // GetCalls gets all the calls that were made to Get.
@@ -211,12 +203,10 @@ func (mock *SparkApplicationRepositoryMock) Get(ctx context.Context, namespace s
 //
 //	len(mockedSparkApplicationRepository.GetCalls())
 func (mock *SparkApplicationRepositoryMock) GetCalls() []struct {
-	Ctx       context.Context
 	Namespace string
 	Name      string
 } {
 	var calls []struct {
-		Ctx       context.Context
 		Namespace string
 		Name      string
 	}
@@ -227,17 +217,15 @@ func (mock *SparkApplicationRepositoryMock) GetCalls() []struct {
 }
 
 // GetLogs calls GetLogsFunc.
-func (mock *SparkApplicationRepositoryMock) GetLogs(ctx context.Context, namespace string, name string, tailLines int64) (*string, error) {
+func (mock *SparkApplicationRepositoryMock) GetLogs(namespace string, name string, tailLines int64) (*string, error) {
 	if mock.GetLogsFunc == nil {
 		panic("SparkApplicationRepositoryMock.GetLogsFunc: method is nil but SparkApplicationRepository.GetLogs was just called")
 	}
 	callInfo := struct {
-		Ctx       context.Context
 		Namespace string
 		Name      string
 		TailLines int64
 	}{
-		Ctx:       ctx,
 		Namespace: namespace,
 		Name:      name,
 		TailLines: tailLines,
@@ -245,7 +233,7 @@ func (mock *SparkApplicationRepositoryMock) GetLogs(ctx context.Context, namespa
 	mock.lockGetLogs.Lock()
 	mock.calls.GetLogs = append(mock.calls.GetLogs, callInfo)
 	mock.lockGetLogs.Unlock()
-	return mock.GetLogsFunc(ctx, namespace, name, tailLines)
+	return mock.GetLogsFunc(namespace, name, tailLines)
 }
 
 // GetLogsCalls gets all the calls that were made to GetLogs.
@@ -253,13 +241,11 @@ func (mock *SparkApplicationRepositoryMock) GetLogs(ctx context.Context, namespa
 //
 //	len(mockedSparkApplicationRepository.GetLogsCalls())
 func (mock *SparkApplicationRepositoryMock) GetLogsCalls() []struct {
-	Ctx       context.Context
 	Namespace string
 	Name      string
 	TailLines int64
 } {
 	var calls []struct {
-		Ctx       context.Context
 		Namespace string
 		Name      string
 		TailLines int64
@@ -271,21 +257,19 @@ func (mock *SparkApplicationRepositoryMock) GetLogsCalls() []struct {
 }
 
 // List calls ListFunc.
-func (mock *SparkApplicationRepositoryMock) List(ctx context.Context, namespace string) ([]*metav1.ObjectMeta, error) {
+func (mock *SparkApplicationRepositoryMock) List(namespace string) ([]*model.SparkManagerApplicationMeta, error) {
 	if mock.ListFunc == nil {
 		panic("SparkApplicationRepositoryMock.ListFunc: method is nil but SparkApplicationRepository.List was just called")
 	}
 	callInfo := struct {
-		Ctx       context.Context
 		Namespace string
 	}{
-		Ctx:       ctx,
 		Namespace: namespace,
 	}
 	mock.lockList.Lock()
 	mock.calls.List = append(mock.calls.List, callInfo)
 	mock.lockList.Unlock()
-	return mock.ListFunc(ctx, namespace)
+	return mock.ListFunc(namespace)
 }
 
 // ListCalls gets all the calls that were made to List.
@@ -293,11 +277,9 @@ func (mock *SparkApplicationRepositoryMock) List(ctx context.Context, namespace 
 //
 //	len(mockedSparkApplicationRepository.ListCalls())
 func (mock *SparkApplicationRepositoryMock) ListCalls() []struct {
-	Ctx       context.Context
 	Namespace string
 } {
 	var calls []struct {
-		Ctx       context.Context
 		Namespace string
 	}
 	mock.lockList.RLock()

--- a/internal/sparkManager/application/service/service_test.go
+++ b/internal/sparkManager/application/service/service_test.go
@@ -53,10 +53,10 @@ var testCluster model.KubeCluster = model.KubeCluster{
 }
 
 var mockSparkAppRepository_SuccessTests SparkApplicationRepositoryMock = SparkApplicationRepositoryMock{
-	GetFunc: func(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplication, error) {
+	GetFunc: func(namespace string, name string) (*v1beta2.SparkApplication, error) {
 		return &expectedSparkApplication, nil
 	},
-	GetLogsFunc: func(ctx context.Context, namespace string, name string, tailLine int64) (*string, error) {
+	GetLogsFunc: func(namespace string, name string, tailLine int64) (*string, error) {
 		return &logString, nil
 	},
 	CreateFunc: func(ctx context.Context, application *v1beta2.SparkApplication) (*v1beta2.SparkApplication, error) {
@@ -68,10 +68,10 @@ var mockSparkAppRepository_SuccessTests SparkApplicationRepositoryMock = SparkAp
 }
 
 var mockSparkAppRepository_FailureTests SparkApplicationRepositoryMock = SparkApplicationRepositoryMock{
-	GetFunc: func(ctx context.Context, namespace string, name string) (*v1beta2.SparkApplication, error) {
+	GetFunc: func(namespace string, name string) (*v1beta2.SparkApplication, error) {
 		return nil, gatewayerrors.NewNotFound(fmt.Errorf("error getting SparkApplication '%s/%s'", expectedSparkApplication.Namespace, expectedSparkApplication.Name))
 	},
-	GetLogsFunc: func(ctx context.Context, namespace string, name string, tailLine int64) (*string, error) {
+	GetLogsFunc: func(namespace string, name string, tailLine int64) (*string, error) {
 		return nil, errors.New("error getting logs")
 	},
 	CreateFunc: func(ctx context.Context, application *v1beta2.SparkApplication) (*v1beta2.SparkApplication, error) {
@@ -85,7 +85,7 @@ var mockSparkAppRepository_FailureTests SparkApplicationRepositoryMock = SparkAp
 func TestSparkApplicationService_Get(t *testing.T) {
 	service := NewSparkApplicationService(&mockSparkAppRepository_SuccessTests, nil, testCluster)
 
-	result, err := service.Get(context.Background(), "testNamespace", "clusterid-nsid-testid")
+	result, err := service.Get("testNamespace", "clusterid-nsid-testid")
 	assert.NoError(t, err)
 	assert.Equal(t, &expectedSparkApplication, result)
 }
@@ -93,7 +93,7 @@ func TestSparkApplicationService_Get(t *testing.T) {
 func TestSparkApplicationService_Get_Error(t *testing.T) {
 	service := NewSparkApplicationService(&mockSparkAppRepository_FailureTests, nil, testCluster)
 
-	_, err := service.Get(context.Background(), "testNamespace", "clusterid-nsid-testid")
+	_, err := service.Get("testNamespace", "clusterid-nsid-testid")
 	assert.Error(t, err)
 	assert.Equal(t, gatewayerrors.NewNotFound(fmt.Errorf("error getting SparkApplication '%s/%s'", expectedSparkApplication.Namespace, expectedSparkApplication.Name)), err)
 }
@@ -101,7 +101,7 @@ func TestSparkApplicationService_Get_Error(t *testing.T) {
 func TestSparkApplicationService_Status(t *testing.T) {
 	service := NewSparkApplicationService(&mockSparkAppRepository_SuccessTests, nil, testCluster)
 
-	result, err := service.Get(context.Background(), "testNamespace", "clusterid-nsid-testid")
+	result, err := service.Get("testNamespace", "clusterid-nsid-testid")
 	assert.NoError(t, err)
 	assert.Equal(t, &expectedSparkApplication, result)
 }
@@ -109,7 +109,7 @@ func TestSparkApplicationService_Status(t *testing.T) {
 func TestSparkApplicationService_Status_Error(t *testing.T) {
 	service := NewSparkApplicationService(&mockSparkAppRepository_FailureTests, nil, testCluster)
 
-	_, err := service.Get(context.Background(), "testNamespace", "clusterid-nsid-testid")
+	_, err := service.Get("testNamespace", "clusterid-nsid-testid")
 	assert.Error(t, err)
 	assert.Equal(t, gatewayerrors.NewNotFound(fmt.Errorf("error getting SparkApplication '%s/%s'", expectedSparkApplication.Namespace, expectedSparkApplication.Name)), err)
 }
@@ -117,7 +117,7 @@ func TestSparkApplicationService_Status_Error(t *testing.T) {
 func TestSparkApplicationService_GetLogs(t *testing.T) {
 	service := NewSparkApplicationService(&mockSparkAppRepository_SuccessTests, nil, testCluster)
 
-	result, err := service.Logs(context.Background(), "testNamespace", "clusterid-nsid-testid", 100)
+	result, err := service.Logs("testNamespace", "clusterid-nsid-testid", 100)
 	assert.NoError(t, err)
 	assert.Equal(t, &logString, result)
 }
@@ -125,7 +125,7 @@ func TestSparkApplicationService_GetLogs(t *testing.T) {
 func TestSparkApplicationService_GetLogs_Error(t *testing.T) {
 	service := NewSparkApplicationService(&mockSparkAppRepository_FailureTests, nil, testCluster)
 
-	_, err := service.Logs(context.Background(), "testNamespace", "clusterid-nsid-testid", 100)
+	_, err := service.Logs("testNamespace", "clusterid-nsid-testid", 100)
 	assert.Error(t, err)
 	assert.Equal(t, errors.New("error getting logs"), err)
 }

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -79,7 +79,7 @@ func ParseGatewayIdUUID(gatewayId string) (*uuid.UUID, error) {
 }
 
 type SparkManagerApplicationMeta struct {
-	ObjectMeta metav1.ObjectMeta `json:"meta"`
+	ObjectMeta metav1.ObjectMeta `json:"metadata"`
 	// All fields below come from v1beta2.SparkApplicationStatus
 	// Currently it's all fields except for ExecutorState because it can get pretty large
 	SparkApplicationID        string                   `json:"sparkApplicationId"`
@@ -93,8 +93,8 @@ type SparkManagerApplicationMeta struct {
 }
 
 type GatewayApplicationMeta struct {
-	SparkManagerApplicationMeta SparkManagerApplicationMeta
-	Cluster                     string `json:"cluster"`
+	SparkAppMeta SparkManagerApplicationMeta `json:"sparkAppMetadata"`
+	Cluster      string                      `json:"cluster"`
 }
 
 func NewSparkManagerApplicationMeta(sparkApp *v1beta2.SparkApplication) *SparkManagerApplicationMeta {
@@ -123,7 +123,7 @@ func NewSparkManagerApplicationMeta(sparkApp *v1beta2.SparkApplication) *SparkMa
 
 func NewGatewayApplicationMeta(smAppMeta *SparkManagerApplicationMeta, cluster string) *GatewayApplicationMeta {
 	return &GatewayApplicationMeta{
-		SparkManagerApplicationMeta: *smAppMeta,
-		Cluster:                     cluster,
+		SparkAppMeta: *smAppMeta,
+		Cluster:      cluster,
 	}
 }

--- a/pkg/model/application.go
+++ b/pkg/model/application.go
@@ -17,11 +17,13 @@ package model
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/google/uuid"
 	"github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
 )
+
+const GATEWAY_USER_LABEL = "spark-gateway/user"
 
 type SparkLogURLs struct {
 	SparkUI        string `json:"sparkUI"`
@@ -74,4 +76,54 @@ func ParseGatewayIdUUID(gatewayId string) (*uuid.UUID, error) {
 		return &uid, nil
 	}
 	return nil, fmt.Errorf("error parsing gatewayId (%s). Format must be 'cluster-namespace-uuid'", gatewayId)
+}
+
+type SparkManagerApplicationMeta struct {
+	ObjectMeta metav1.ObjectMeta `json:"meta"`
+	// All fields below come from v1beta2.SparkApplicationStatus
+	// Currently it's all fields except for ExecutorState because it can get pretty large
+	SparkApplicationID        string                   `json:"sparkApplicationId"`
+	SubmissionID              string                   `json:"submissionID"`
+	LastSubmissionAttemptTime metav1.Time              `json:"lastSubmissionAttemptTime"`
+	TerminationTime           metav1.Time              `json:"terminationTime"`
+	DriverInfo                v1beta2.DriverInfo       `json:"driverInfo"`
+	AppState                  v1beta2.ApplicationState `json:"applicationState"`
+	ExecutionAttempts         int32                    `json:"executionAttempts"`
+	SubmissionAttempts        int32                    `json:"submissionAttempts"`
+}
+
+type GatewayApplicationMeta struct {
+	SparkManagerApplicationMeta SparkManagerApplicationMeta
+	Cluster                     string `json:"cluster"`
+}
+
+func NewSparkManagerApplicationMeta(sparkApp *v1beta2.SparkApplication) *SparkManagerApplicationMeta {
+
+	if sparkApp == nil {
+		return nil
+	}
+
+	// managedFields can be large and is not a required field
+	sparkApp.ManagedFields = nil
+	return &SparkManagerApplicationMeta{
+		ObjectMeta: sparkApp.ObjectMeta,
+		// All fields below come from v1beta2.SparkApplicationStatus
+		// Currently it's all fields except for ExecutorState because it can get pretty large
+		SparkApplicationID:        sparkApp.Status.SparkApplicationID,
+		SubmissionID:              sparkApp.Status.SubmissionID,
+		LastSubmissionAttemptTime: sparkApp.Status.LastSubmissionAttemptTime,
+		TerminationTime:           sparkApp.Status.TerminationTime,
+		DriverInfo:                sparkApp.Status.DriverInfo,
+		AppState:                  sparkApp.Status.AppState,
+		ExecutionAttempts:         sparkApp.Status.ExecutionAttempts,
+		SubmissionAttempts:        sparkApp.Status.SubmissionAttempts,
+	}
+
+}
+
+func NewGatewayApplicationMeta(smAppMeta *SparkManagerApplicationMeta, cluster string) *GatewayApplicationMeta {
+	return &GatewayApplicationMeta{
+		SparkManagerApplicationMeta: *smAppMeta,
+		Cluster:                     cluster,
+	}
 }


### PR DESCRIPTION
Refactor list endpoints to include more metadata. This metadata will be used for the UI.
Summary:
- Create `SparkManagerApplicationMeta` and `GatewayApplicationMeta` which are returned by the List endpoints for SparkManager and Gateway respectively.
- Update interfaces to reflect above change
- Mock objects and docs