### PR TITLE
fix(helm): align DB config path with config struct and base values

### DIFF
--- a/helm/spark-gateway/templates/_helpers.tpl
+++ b/helm/spark-gateway/templates/_helpers.tpl
@@ -112,10 +112,10 @@ Gateway Config Configurations
 {{- define "spark-gateway.config" -}}
 {{- if .Values.postgresql.create }}
 {{- $dbHostName := printf "%s-postgresql.%s.svc.cluster.local" (include "spark-gateway.fullname" .) .Release.Namespace }}
-{{- $_ := set .Values.config.sparkManager.database "hostname" $dbHostName }}
-{{- $_ = set .Values.config.sparkManager.database "port" 5432 }}
-{{- $_ = set .Values.config.sparkManager.database "databaseName" "postgres" }}
-{{- $_ = set .Values.config.sparkManager.database "username" "postgres" }}
+{{- $_ := set .Values.config.database "hostname" $dbHostName }}
+{{- $_ = set .Values.config.database "port" 5432 }}
+{{- $_ = set .Values.config.database "databaseName" "postgres" }}
+{{- $_ = set .Values.config.database "username" "postgres" }}
 {{- end }}
 {{- if or .Values.sparkManager.multiClusterRouting.certificateAuthority.externalSecret.create (ne .Values.sparkManager.multiClusterRouting.certificateAuthority.existingSecretName "") }}
 {{- range $_, $cluster := .Values.config.clusters }}

--- a/helm/spark-gateway/templates/sparkManager/deployment.yaml
+++ b/helm/spark-gateway/templates/sparkManager/deployment.yaml
@@ -69,7 +69,7 @@ spec:
             mountPath: {{ $.Values.sparkManager.multiClusterRouting.certificateAuthority.mountPath }}
             readOnly: true
         {{- end }}
-        {{ if $.Values.config.sparkManager.database.enable }}
+        {{ if $.Values.config.database.enable }}
         env:
           {{- include "spark-gateway.database.passwordEnvVars" $ | indent 10 }}
         {{- end}}


### PR DESCRIPTION
# What
The chart's base values.yaml defines the database config at the top level (config.database), matching the Go config struct (koanf:"database"), but two templates still referenced the old config.sparkManager.database path:

- sparkManager/deployment.yaml gated the DB_PASSWORD env on config.sparkManager.database.enable, so with the database enabled the password env was never injected and the sparkManager failed config validation at startup.
- _helpers.tpl postgresql autoconfig wrote hostname/port/databaseName/username to config.sparkManager.database, which the binary does not read.

Repoint both to config.database. Default values ship DB disabled, so this is inert for the default install and only fixes the database-enabled path.

Verified: helm template with config.database.enable=true now renders the DB_PASSWORD env on the sparkManager Deployment; helm unittest 14/14.