### PR TITLE
fix(auth): close auth-bypass gaps and use constant-time token compare

### DIFF
--- a/internal/gateway/api/middleware/mw_regex_basic_auth.go
+++ b/internal/gateway/api/middleware/mw_regex_basic_auth.go
@@ -107,6 +107,7 @@ func (r *RegexBasicAuthAllowMiddleware) Handler(c *gin.Context) {
 			c.Set("user", authUser)
 		} else {
 			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "user is unauthorized"})
+			return
 		}
 	}
 
@@ -184,6 +185,7 @@ func (r *RegexBasicAuthDenyMiddleware) Handler(c *gin.Context) {
 
 		if denyUser := r.DenyUsername(authUser); denyUser {
 			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "user is unauthorized"})
+			return
 		}
 
 	}

--- a/internal/gateway/api/middleware/mw_service_auth.go
+++ b/internal/gateway/api/middleware/mw_service_auth.go
@@ -16,6 +16,7 @@
 package middleware
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"net/http"
 
@@ -102,11 +103,12 @@ func (s *ServiceTokenAuthMiddleware) Handler(c *gin.Context) {
 	// If user set but no token, we refuse
 	if serviceToken == "" {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "X-Spark-Gateway-Token is not set"})
+		return
 	}
 
 	// Check if service is authorized
 	if gotToken, found := s.ServiceTokenMap[serviceName]; found {
-		if serviceToken == gotToken {
+		if subtle.ConstantTimeCompare([]byte(serviceToken), []byte(gotToken)) == 1 {
 			c.Set("user", serviceName)
 			c.Next()
 			return


### PR DESCRIPTION
## Summary
Hardens the gateway authentication middleware against two real auth-bypass paths and a timing side-channel.

## Findings addressed
- **Missing `return` after abort** (`mw_service_auth.go`): a request with `X-Spark-Gateway-User` set but an empty token aborted, then fell through into the token-map lookup. If any service were configured with an empty-string token, the empty submitted token would match. Added the `return`.
- **Non-constant-time token compare** (`mw_service_auth.go`): `serviceToken == gotToken` short-circuits on the first differing byte, leaking token length/prefix via timing. Switched to `crypto/subtle.ConstantTimeCompare`.
- **Regex allow/deny handlers** (`mw_regex_basic_auth.go`): both aborted with 403 then continued into `c.Next()`. Added `return` after the abort.

## Testing
`go build ./...`, `go vet`, and `go test ./internal/gateway/api/...` all pass.