### PR TITLE
fix(config): apply routing-weight defaults via slice index

### DIFF
--- a/internal/shared/config/config.go
+++ b/internal/shared/config/config.go
@@ -252,14 +252,14 @@ func (c *SparkGatewayConfig) ConfigDefaulter() {
 
 func (c *SparkGatewayConfig) KubeClustersDefaulter() {
 	// set default routingWeight to 1
-	for _, c := range c.KubeClusters {
-		if c.RoutingWeight == float64(0) {
-			c.RoutingWeight = 1.0
+	for i := range c.KubeClusters {
+		if c.KubeClusters[i].RoutingWeight == float64(0) {
+			c.KubeClusters[i].RoutingWeight = 1.0
 		}
 
-		for _, ns := range c.Namespaces {
-			if ns.RoutingWeight == float64(0) {
-				ns.RoutingWeight = 1.0
+		for j := range c.KubeClusters[i].Namespaces {
+			if c.KubeClusters[i].Namespaces[j].RoutingWeight == float64(0) {
+				c.KubeClusters[i].Namespaces[j].RoutingWeight = 1.0
 			}
 		}
 	}

--- a/internal/shared/config/config_test.go
+++ b/internal/shared/config/config_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/knadh/koanf/v2"
+	"github.com/slackhq/spark-gateway/internal/domain"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -85,4 +86,28 @@ port: 8080
 	err = ConfigUnmarshal(tmpFile.Name(), &conf)
 
 	assert.Contains(t, err.Error(), "error parsing config file:", "expected error")
+}
+
+func TestKubeClustersDefaulter(t *testing.T) {
+	conf := SparkGatewayConfig{
+		KubeClusters: []domain.KubeCluster{
+			{
+				Name: "unset-weight",
+				Namespaces: []domain.KubeNamespace{
+					{Name: "ns-unset"},
+					{Name: "ns-set", RoutingWeight: 3.0},
+				},
+			},
+			{Name: "set-weight", RoutingWeight: 5.0},
+		},
+	}
+
+	conf.KubeClustersDefaulter()
+
+	// Unset cluster/namespace weights default to 1.0...
+	assert.Equal(t, 1.0, conf.KubeClusters[0].RoutingWeight)
+	assert.Equal(t, 1.0, conf.KubeClusters[0].Namespaces[0].RoutingWeight)
+	// ...while explicitly set weights are preserved.
+	assert.Equal(t, 3.0, conf.KubeClusters[0].Namespaces[1].RoutingWeight)
+	assert.Equal(t, 5.0, conf.KubeClusters[1].RoutingWeight)
 }


### PR DESCRIPTION
## Summary
`KubeClustersDefaulter` ranged over the cluster/namespace slices **by value**, so the `RoutingWeight = 1.0` assignments mutated loop copies and were discarded. Clusters/namespaces with an unset weight stayed at `0`, which skews the weight-based cluster router (zero weight = never selected).

## Fix
Index the slices directly so defaults persist. Added `TestKubeClustersDefaulter` covering both defaulted and explicitly-set weights.

## Testing
`go test ./internal/shared/config/...` passes.