### PR TITLE
fix(gateway): validate gatewayId before indexing split parts

### DIFF
--- a/internal/gateway/service/application_service.go
+++ b/internal/gateway/service/application_service.go
@@ -90,14 +90,20 @@ func NewApplicationService(
 }
 
 func (s *service) GetClusterNamespaceFromGatewayId(gatewayId string) (*domain.KubeCluster, string, error) {
-	clusterId := strings.Split(gatewayId, "-")[0]
+	// gatewayId format is 'clusterId-namespaceId-uuid'.
+	parts := strings.SplitN(gatewayId, "-", 3)
+	if len(parts) < 3 {
+		return nil, "", gatewayerrors.NewBadRequest(fmt.Errorf("invalid gatewayId '%s', format must be 'cluster-namespace-uuid'", gatewayId))
+	}
+
+	clusterId := parts[0]
 	kubeCluster, err := s.clusterRepository.GetById(clusterId)
 
 	if err != nil {
 		return nil, "", gatewayerrors.NewInternal(fmt.Errorf("error getting cluster parsed from gatewayId: %w", err))
 	}
 
-	namespaceId := strings.Split(gatewayId, "-")[1]
+	namespaceId := parts[1]
 	namespace, err := kubeCluster.GetNamespaceById(namespaceId)
 
 	if err != nil {

--- a/internal/gateway/service/application_service_test.go
+++ b/internal/gateway/service/application_service_test.go
@@ -357,6 +357,24 @@ func TestServiceGetNotFound(t *testing.T) {
 
 }
 
+func TestServiceGetMalformedGatewayId(t *testing.T) {
+	appService := NewApplicationService(
+		&mockGatewayAppRepository_Success,
+		mockClusterRepo_Success,
+		&SuccessClusterRouter{},
+		&SuccessClusterRouter{},
+		testGatewayConfig,
+		"",
+		"",
+		GatewayIdGenerator_Success,
+	)
+
+	gatewayApp, err := appService.Get(context.Background(), "noseparators")
+
+	assert.Nil(t, gatewayApp, "returned GatewayApplication should be nil")
+	assert.Contains(t, err.Error(), "invalid gatewayId", "error should report invalid gatewayId")
+}
+
 func TestList(t *testing.T) {
 	appService := NewApplicationService(
 		&mockGatewayAppRepository_Success,


### PR DESCRIPTION
## Summary
`GetClusterNamespaceFromGatewayId` indexed `strings.Split(gatewayId, "-")[1]` directly, panicking with index-out-of-range on a client-supplied id containing no `-`. Gin's recovery turned it into a 500 rather than a 400.

## Fix
Use `SplitN` and return a `400 BadRequest` for malformed ids. Added `TestServiceGetMalformedGatewayId`.

## Testing
`go build` and `go test ./internal/gateway/service/...` pass.