### PR TITLE
fix(http): use a shared client with timeout for SparkManager calls

### DIFF
--- a/internal/gateway/clusterrouter/weight_based_router.go
+++ b/internal/gateway/clusterrouter/weight_based_router.go
@@ -271,7 +271,7 @@ func GetClusterMetricFamilies(
 		return nil, gatewayerrors.NewFrom(fmt.Errorf("error creating %s request: %w", "GET", err))
 	}
 
-	resp, respBody, err := sgHttp.HttpRequest(ctx, &http.Client{}, request)
+	resp, respBody, err := sgHttp.HttpRequest(ctx, sgHttp.DefaultClient, request)
 	if err != nil {
 		return nil, gatewayerrors.NewFrom(err)
 	}

--- a/internal/gateway/repository/application_sparkmanager_repository.go
+++ b/internal/gateway/repository/application_sparkmanager_repository.go
@@ -35,7 +35,7 @@ import (
 // DoHTTP runs a request, checks for errors from making the request or the request body, and returns the Response body bytes
 // if the request succeeds
 func DoHTTP(ctx context.Context, request *http.Request) (*[]byte, error) {
-	resp, respBody, err := sgHttp.HttpRequest(ctx, &http.Client{}, request)
+	resp, respBody, err := sgHttp.HttpRequest(ctx, sgHttp.DefaultClient, request)
 	if err != nil {
 		return nil, gatewayerrors.NewFrom(err)
 	}

--- a/internal/shared/http/http.go
+++ b/internal/shared/http/http.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -30,6 +31,20 @@ import (
 
 type HttpError struct {
 	Error string `json:"error"`
+}
+
+// DefaultClient is a shared HTTP client for internal SparkManager calls. It
+// carries an overall request timeout so a hung peer cannot pin a goroutine
+// indefinitely, and reuses connections via a pooled transport. Reuse this
+// rather than allocating a new http.Client per request, which defeats
+// keep-alive.
+var DefaultClient = &http.Client{
+	Timeout: 30 * time.Second,
+	Transport: &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 10,
+		IdleConnTimeout:     90 * time.Second,
+	},
 }
 
 func HttpRequest(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, *[]byte, error) {


### PR DESCRIPTION
## Summary
`DoHTTP` and the weight-based router's metrics fetch each allocated a bare `&http.Client{}` per call, which has **no timeout** (a hung SparkManager or metrics endpoint could pin a goroutine indefinitely) and defeats connection keep-alive.

## Fix
Add a shared `sgHttp.DefaultClient` with a 30s timeout and a pooled transport (MaxIdleConns/perHost/IdleConnTimeout), used at both call sites.

## Testing
`go build`, `go vet`, `go test ./internal/gateway/... ./internal/shared/http/...` pass.