### PR TITLE
fix(database): harden connection setup and tune the pool

### DIFF
--- a/internal/gateway/server/server.go
+++ b/internal/gateway/server/server.go
@@ -90,8 +90,11 @@ func NewGateway(ctx context.Context, sgConfig *config.SparkGatewayConfig, sparkM
 	// Livy Setup
 	var livyService service.LivyApplicationService
 	if sgConfig.LivyConfig.Enable {
-		database := database.NewDatabase(ctx, sgConfig.Database)
-		livyService = service.NewLivyService(appService, database, sgConfig.LivyConfig.DefaultNamespace, sgConfig.GatewayConfig.StatusUrlTemplates)
+		livyDB, err := database.NewDatabase(ctx, sgConfig.Database)
+		if err != nil {
+			return nil, fmt.Errorf("error creating database: %w", err)
+		}
+		livyService = service.NewLivyService(appService, livyDB, sgConfig.LivyConfig.DefaultNamespace, sgConfig.GatewayConfig.StatusUrlTemplates)
 	}
 
 	router, err := api.NewRouter(sgConfig, appService, livyService)

--- a/internal/shared/database/database.go
+++ b/internal/shared/database/database.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"k8s.io/klog/v2"
 
@@ -33,6 +34,10 @@ import (
 
 	"github.com/slackhq/spark-gateway/internal/shared/gatewayerrors"
 )
+
+// statementTimeout bounds how long any single query may run on the server,
+// protecting pooled connections from being held indefinitely by a wedged query.
+const statementTimeout = "30s"
 
 //go:generate moq -rm -out mocksparkapplicationdatabase.go . SparkApplicationDatabase
 
@@ -56,9 +61,22 @@ type Database struct {
 }
 
 func GetConnectionPool(ctx context.Context, connectionString string) (*pgxpool.Pool, error) {
-	dbpool, err := pgxpool.New(ctx, connectionString)
+	poolConfig, err := pgxpool.ParseConfig(connectionString)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to create connection pool: %v\n", err)
+		return nil, fmt.Errorf("unable to parse database connection string: %w", err)
+	}
+
+	// Tune the pool so it does not grow unbounded and recycles connections,
+	// which keeps connections fresh against Postgres/PgBouncer.
+	poolConfig.MaxConns = 20
+	poolConfig.MinConns = 2
+	poolConfig.MaxConnLifetime = time.Hour
+	poolConfig.MaxConnIdleTime = 30 * time.Minute
+	poolConfig.HealthCheckPeriod = time.Minute
+
+	dbpool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create connection pool: %w", err)
 	}
 
 	return dbpool, nil
@@ -66,31 +84,33 @@ func GetConnectionPool(ctx context.Context, connectionString string) (*pgxpool.P
 
 func GetConnectionString(databaseConfig config.Database) string {
 
-	// postgres://{user}:{password}@{hostname}:{port}/{database-name}
+	// postgres://{user}:{password}@{hostname}:{port}/{database-name}?statement_timeout=...
 	klog.Infof("Database Info: %s:%s/%s\n",
 		databaseConfig.Hostname,
 		databaseConfig.Port,
 		databaseConfig.DatabaseName,
 	)
-	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s",
-		databaseConfig.Username,
-		databaseConfig.Password,
-		databaseConfig.Hostname,
-		databaseConfig.Port,
-		databaseConfig.DatabaseName,
-	)
+
+	dsn := url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(databaseConfig.Username, databaseConfig.Password),
+		Host:     fmt.Sprintf("%s:%s", databaseConfig.Hostname, databaseConfig.Port),
+		Path:     databaseConfig.DatabaseName,
+		RawQuery: url.Values{"statement_timeout": {statementTimeout}}.Encode(),
+	}
+	return dsn.String()
 }
 
-func NewDatabase(ctx context.Context, dbConfig config.Database) *Database {
+func NewDatabase(ctx context.Context, dbConfig config.Database) (*Database, error) {
 	connectionString := GetConnectionString(dbConfig)
 	connectionPool, err := GetConnectionPool(ctx, connectionString)
 	if err != nil {
-		klog.Fatal(fmt.Errorf("could not create DatabaseRepository connection: %w", err))
+		return nil, fmt.Errorf("could not create DatabaseRepository connection: %w", err)
 	}
 
 	return &Database{
 		connectionPool: connectionPool,
-	}
+	}, nil
 }
 
 func (db *Database) GetById(ctx context.Context, gatewayIdUid uuid.UUID) (*SparkApplication, error) {

--- a/internal/sparkManager/server.go
+++ b/internal/sparkManager/server.go
@@ -53,7 +53,11 @@ func NewSparkManager(ctx context.Context, sgConfig *config.SparkGatewayConfig, c
 	// Create DB Repo
 	var db database.SparkApplicationDatabase = nil
 	if sgConfig.Database.Enable {
-		db = database.NewDatabase(ctx, sgConfig.Database)
+		sparkAppDB, err := database.NewDatabase(ctx, sgConfig.Database)
+		if err != nil {
+			return nil, fmt.Errorf("error creating database: %w", err)
+		}
+		db = sparkAppDB
 	}
 
 	// Initialize Kube Clients


### PR DESCRIPTION
## Summary
Hardens Postgres connection setup.

## Findings addressed
- **DSN string interpolation**: password injected raw, so credentials with reserved chars (`@ : / ?`) corrupt the connection string. Now built with `net/url` (verified: `p@ss:w/rd?` → `p%40ss%3Aw%2Frd%3F`).
- **Untuned pool**: `pgxpool.New` used defaults only. Set explicit MaxConns/MinConns/MaxConnLifetime/MaxConnIdleTime/HealthCheckPeriod via `ParseConfig` + `NewWithConfig`.
- **No query timeout**: added a server-side `statement_timeout` so a wedged query can't hold a pooled connection indefinitely.
- **`klog.Fatal` in a shared lib**: `NewDatabase` now returns an error; both server callers propagate it.

## Testing
`go build` and full `go test ./...` (11 packages) pass.