### PR TITLE
chore(security): gitignore config/local.yaml to avoid committing secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ go.work.sum
 # env file
 .env
 
+# Local config may contain secrets (e.g. DB password)
+config/local.yaml
+
 # Editor/IDE
 .idea/
 .vscode/


### PR DESCRIPTION
## Summary
`config/local.yaml` carries a plaintext DB password for local runs and was **not** ignored, so a routine `git add .` would commit a live credential.

## Fix
Add `config/local.yaml` to `.gitignore`. `config/gateway-config-dev.yaml` remains the committed template.

> Note: if the password currently in that file is a real/shared credential, rotate it.