### PR TITLE
fix(docker): run on a minimal non-root runtime with a real entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,17 @@ RUN go build -o /sparkManager ./cmd/sparkManager/
 # build tests
 RUN go build -o /tests ./cmd/tests/
 
-FROM golang:1.24.2 AS runner
-RUN apt update && apt upgrade -y
+FROM alpine:3.20 AS runner
+
+# tini for proper signal handling/zombie reaping; ca-certificates for TLS.
+RUN apk add --no-cache tini ca-certificates \
+    && addgroup -S spark && adduser -S -G spark spark
 
 COPY --from=build /gateway /gateway
 COPY --from=build /sparkManager /sparkManager
 COPY --from=build /tests /tests
 
-# Add Tini
-RUN apt install -y tini
+USER spark
 
-ENTRYPOINT ["/sbin/tini", "--", "/bin/sh"]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/gateway"]


### PR DESCRIPTION
## Summary
The runtime stage was the full `golang:1.24.2` build image (~800MB, ships the Go toolchain) and its entrypoint dropped into `/bin/sh` rather than running a binary.

## Fix
- Switch runner to `alpine:3.20`.
- Install only `tini` + `ca-certificates` via `apk --no-cache`.
- Add a non-root `spark` user (`USER spark`).
- Entrypoint = `tini --` with default `CMD ["/gateway"]`.

Helm still overrides `command` per container (`/sparkManager`, `/tests`, and the `sh -c` init container all work on alpine).

## Verification
Built locally: image runs as `uid=100(spark)`, `/sbin/tini` present, all three binaries present, shell available for the init container, default CMD launches `/gateway`. Image size **~337MB** (down from ~800MB).