### PR TITLE
fix(router): tolerate unhealthy clusters and guard zero-weight math

### DIFF
--- a/internal/gateway/clusterrouter/weight_based_random_router.go
+++ b/internal/gateway/clusterrouter/weight_based_random_router.go
@@ -98,6 +98,12 @@ func (r *WeightBasedRandomRouter) GetCluster(ctx context.Context, namespace stri
 		return nil, gatewayerrors.NewFrom(fmt.Errorf("unable to find any suitable cluster for routing"))
 	}
 
+	// rand.Intn panics on a non-positive argument, which happens when every
+	// candidate's routing weight is zero.
+	if *totalWeight <= 0 {
+		return nil, gatewayerrors.NewFrom(fmt.Errorf("total routing weight is zero for namespace %s; cannot select a cluster", namespace))
+	}
+
 	randomInt := rand.Intn(int(*totalWeight))
 	chosenClusterId := chooseClusterIDRandom(weightsMap, randomInt)
 

--- a/internal/gateway/clusterrouter/weight_based_router.go
+++ b/internal/gateway/clusterrouter/weight_based_router.go
@@ -138,29 +138,45 @@ func (r *WeightBasedRouter) GetCluster(ctx context.Context, namespace string) (*
 			metricsPort = port.MetricsPort
 		}
 
+		// A single unhealthy cluster should be excluded from routing rather
+		// than fail the entire submission, so per-cluster metric failures log
+		// and drop that cluster from the candidate set instead of returning.
 		metricFamilies, err := GetClusterMetricFamilies(ctx, c, r.sparkManagerHostnameTemplate, metricsPort, r.metricsServerConfig.Endpoint)
 		if err != nil {
-			return nil, gatewayerrors.NewFrom(fmt.Errorf("error getting metrics from SparkManager %s: %w", c.ClusterId, err))
+			klog.Warningf("excluding cluster %s from routing: error getting metrics from SparkManager: %v", c.ClusterId, err)
+			delete(metricsMap, c.ClusterId)
+			continue
 		}
 
 		metricFamily, ok := metricFamilies[r.clusterRouterConfig.PrometheusQuery.Metric]
 		if !ok {
-			return nil, gatewayerrors.NewFrom(fmt.Errorf("could not find metric %s", r.clusterRouterConfig.PrometheusQuery.Metric))
+			klog.Warningf("excluding cluster %s from routing: could not find metric %s", c.ClusterId, r.clusterRouterConfig.PrometheusQuery.Metric)
+			delete(metricsMap, c.ClusterId)
+			continue
 		}
 
 		targetLabels := GetTargetLabels(r.clusterRouterConfig, c.Name, namespace)
 		targetMetrics := GetTargetMetrics(metricFamily.GetMetric(), targetLabels)
-		switch tsLength := len(targetMetrics); {
-		case tsLength == 0:
-			return nil, gatewayerrors.NewFrom(fmt.Errorf("no timeseries exist with target labels: %v", targetMetrics))
-		case tsLength > 1:
-			return nil, gatewayerrors.NewFrom(fmt.Errorf("more than 1 timeseries exist with target labels: %v", targetMetrics))
+		if len(targetMetrics) != 1 {
+			klog.Warningf("excluding cluster %s from routing: expected exactly 1 timeseries with target labels, got %d", c.ClusterId, len(targetMetrics))
+			delete(metricsMap, c.ClusterId)
+			continue
 		}
 
-		metricVal := targetMetrics[0].Gauge.GetValue()
+		gauge := targetMetrics[0].Gauge
+		if gauge == nil {
+			klog.Warningf("excluding cluster %s from routing: metric %s is not a gauge", c.ClusterId, r.clusterRouterConfig.PrometheusQuery.Metric)
+			delete(metricsMap, c.ClusterId)
+			continue
+		}
+		metricVal := gauge.GetValue()
 
 		metricsMap[c.ClusterId].Metric = metricVal
 		totalMetric += metricVal
+	}
+
+	if len(metricsMap) == 0 {
+		return nil, gatewayerrors.NewFrom(fmt.Errorf("no healthy clusters available for routing namespace %s", namespace))
 	}
 
 	chosenClusterId := chooseClusterID(metricsMap, totalMetric)
@@ -221,10 +237,12 @@ func ReadWeightConfigs(metricsMap map[string]*metric, clusters []domain.KubeClus
 		totalWeight += m.Weight
 	}
 
-	// Add weight ratios to weightsMap
+	// Add weight ratios to weightsMap. Guard against a zero total (all weights
+	// unset/zero) which would otherwise make every ratio NaN.
 	for _, m := range metricsMap {
-		r := m.Weight / totalWeight
-		m.WeightRatio = r
+		if totalWeight > 0 {
+			m.WeightRatio = m.Weight / totalWeight
+		}
 	}
 	return metricsMap, &totalWeight
 }


### PR DESCRIPTION
## Summary
Makes the weight-based routers resilient to degraded clusters and bad config.

## Findings addressed
- **One unhealthy cluster failed all routing**: a per-cluster metrics failure (unreachable endpoint, missing metric family, wrong timeseries count) returned immediately, blocking routing to every healthy cluster. Now logs and drops that cluster from the candidate set; only errors if no healthy cluster remains.
- **Gauge nil deref**: `targetMetrics[0].Gauge.GetValue()` assumed a gauge; a non-gauge metric would panic. Added a nil check.
- **NaN weight ratios**: `Weight / totalWeight` when `totalWeight == 0` produced NaN. Guarded.
- **`rand.Intn(0)` panic**: random router panicked when total routing weight was 0. Returns an error instead.

## Testing
`go build`, `go vet`, `go test ./internal/gateway/clusterrouter/...` and full `go test ./...` pass.